### PR TITLE
Tezos X alias registry: index Initialized events into L2Account

### DIFF
--- a/configs/tezosx-shadownet.yaml
+++ b/configs/tezosx-shadownet.yaml
@@ -82,6 +82,12 @@ contracts:
     address: '0x0000000000000000000000000000000000000000'
     typename: kernel_native
 
+  # TEZOSX_CALLER — kernel-only injector: synthetic `from` of all init_tezosx_alias txs
+  # (and other kernel-injected Tezos X calls, e.g. claim_xtz).
+  tezosx_caller:
+    kind: evm
+    address: '0x7e20580000000000000000000000000000000001'
+
   l2_withdrawal_precompile_fa:
     kind: evm
     address: '0xff00000000000000000000000000000000000002'
@@ -203,6 +209,18 @@ indexes:
         pattern:
           - type: transaction
             source: tezos_x_michelson_depositor
+
+  # Alias registry: every Tezos X alias emits Initialized(string,bytes,uint256) once, from its
+  # own address — not wildcard-subscribable, so we filter txs by the kernel injector `from_`
+  # and parse receipt logs in the handler (handlers/etherlink/on_alias_initialized.py).
+  etherlink_alias_initialized_transactions:
+    kind: evm.transactions
+    first_level: ${L2_FIRST_LEVEL}
+    datasources:
+      - etherlink_node
+    handlers:
+      - callback: etherlink.on_alias_initialized
+        from_: tezosx_caller
 
   etherlink_withdrawal_events:
     kind: evm.events

--- a/handlers/etherlink/on_alias_initialized.py
+++ b/handlers/etherlink/on_alias_initialized.py
@@ -1,0 +1,44 @@
+from dipdup.context import HandlerContext
+from dipdup.models.evm import EvmTransactionData
+from eth_abi import decode
+from eth_typing import HexStr
+
+from rollup_bridge_indexer.models import L2Account
+from rollup_bridge_indexer.models import L2AccountKind
+
+# keccak256('Initialized(string,bytes,uint256)') — emitted exactly once per alias by the shared
+# AliasForwarder code, from the alias address itself (log.address = alias). No indexed params:
+# nativeAddress, nativePublicKey and forwardedBalance all live in `data`.
+INITIALIZED_TOPIC0 = bytes.fromhex('60a9f8ac7be7e117b08e5ff52239667fcf051d55e03ead4bfa34c73ff86642e0')
+
+
+async def on_alias_initialized(
+    ctx: HandlerContext,
+    transaction: EvmTransactionData,
+) -> None:
+    # DipDup can't wildcard-subscribe events (every alias emits from its own address), so the index
+    # filters transactions by `from_` = TEZOSX_CALLER (kernel-only injector of init_tezosx_alias txs)
+    # and we pull the receipt logs ourselves. Most such txs (claim_xtz, plain forwards) carry no
+    # Initialized log and are skipped silently.
+    datasource = ctx.get_evm_node_datasource('etherlink_node')
+    receipt = await datasource.web3.eth.get_transaction_receipt(HexStr(transaction.hash))
+
+    for log in receipt['logs']:
+        topics = log['topics']
+        if not topics or bytes(topics[0]) != INITIALIZED_TOPIC0:
+            continue
+
+        native_address, _native_public_key, _forwarded_balance = decode(['string', 'bytes', 'uint256'], bytes(log['data']))
+        alias_address = log['address'].lower()[-40:]
+
+        await L2Account.update_or_create(
+            address=alias_address,
+            defaults={
+                'kind': L2AccountKind.evm_alias,
+                'native_tz_address': native_address,
+                'initialized_at_level': transaction.level,
+                'initialized_at_tx': transaction.hash[-64:],
+            },
+        )
+
+        ctx.logger.info('Alias initialized: %s -> %s (level %s)', alias_address, native_address, transaction.level)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -14,6 +14,7 @@ from tortoise.fields.data import JSONField
 from rollup_bridge_indexer.models.enum import BridgeOperationKind
 from rollup_bridge_indexer.models.enum import BridgeOperationStatus
 from rollup_bridge_indexer.models.enum import BridgeOperationType
+from rollup_bridge_indexer.models.enum import L2AccountKind
 from rollup_bridge_indexer.models.enum import RollupInboxMessageType
 from rollup_bridge_indexer.models.enum import RollupOutboxMessageBuilder
 
@@ -106,6 +107,27 @@ class EtherlinkToken(Model):
         source_field='ticket_hash',
         to_field='hash',
     )
+
+
+class L2Account(Model):
+    """L2 account registry (alias registry).
+
+    Standalone in PR-1: rows are created only by `etherlink.on_alias_initialized` (kind=evm_alias).
+    PR-2 converts l2_deposit/l2_withdrawal `l2_account` columns to FKs onto this table and
+    backfills kind=evm/tz rows for existing addresses.
+    """
+
+    class Meta:
+        table = 'l2_account'
+        model = 'models.L2Account'
+
+    # 40-hex EVM address (no 0x prefix) or base58 tz address.
+    address = fields.CharField(max_length=42, primary_key=True)
+    kind = fields.EnumField(enum_type=L2AccountKind, db_index=True)
+    # Filled for evm_alias rows: the Tezos-side source the alias forwards for (tz1/tz2/tz3 or KT1).
+    native_tz_address = fields.CharField(max_length=36, null=True)
+    initialized_at_level = fields.IntField(null=True)
+    initialized_at_tx = fields.CharField(max_length=64, null=True)
 
 
 class RollupCementedCommitment(DatetimeModelMixin, Model):

--- a/models/enum.py
+++ b/models/enum.py
@@ -14,6 +14,12 @@ class RollupOutboxMessageBuilder(Enum):
     service_provider = 'service_provider'
 
 
+class L2AccountKind(Enum):
+    evm = 'evm'
+    tz = 'tz'
+    evm_alias = 'evm_alias'
+
+
 class BridgeOperationType(Enum):
     deposit = 'deposit'
     withdrawal = 'withdrawal'

--- a/tests/stand/cases/alias_registry/README.md
+++ b/tests/stand/cases/alias_registry/README.md
@@ -1,0 +1,43 @@
+# Case: alias-registry — Tezos X alias `Initialized` events -> `l2_account`
+
+Regression for the **alias registry** (Block 2 / PR-1): standalone `l2_account` table fed by
+`etherlink.on_alias_initialized`. No FK conversion, no matcher integration yet (PR-2).
+
+On Tezos X, a Tezos-native account (tz1/tz2/tz3 or KT1) acting in EVM context gets a forwarder
+**alias** contract that emits `Initialized(string nativeAddress, bytes nativePublicKey,
+uint256 forwardedBalance)` exactly once — **from the alias address itself**, so it cannot be
+event-subscribed (DipDup requires a fixed `contract:`). Production instead filters
+`evm.transactions` by `from_` = TEZOSX_CALLER (`0x7e20580000000000000000000000000000000001`,
+the kernel-only injector of `init_tezosx_alias` txs) and parses the receipt logs in the
+handler, keeping only the `Initialized` topic
+(`0x60a9f8ac7be7e117b08e5ff52239667fcf051d55e03ead4bfa34c73ff86642e0`). Pipeline under test:
+
+- `etherlink.on_alias_initialized` — fetches the tx receipt via the node datasource, abi-decodes
+  `(string, bytes, uint256)`, upserts `l2_account` keyed by the alias address
+  (kind=`evm_alias`); `nativePublicKey` and `Forwarded` events deliberately not stored;
+  txs from the caller without an `Initialized` log (e.g. claim_xtz) are skipped silently.
+
+## Verified on-chain vectors (all 3 Initialized events in previewnet history)
+
+| Level | Alias (event emitter) | nativeAddress | tx |
+|---|---|---|---|
+| 172338 | `0x9adffdb184eae59204995cadfb57aafecc715d73` | `KT19iqeZxnYDz6GbU67uwF4ECH7bY46WTV2v` (KT1, empty pubkey) | `0x61a1e6ec…6499` |
+| 172570 | `0x3f2e3819832be16420810dfafc813334698bfa65` | `tz1ebDT2XwpwP6ja3ESuLUy8BgZwrmi1XpX3` | `0x0068f92f…c6e1` |
+| 176345 | `0x93ee79eb06a7052f3d7f9c160b7927dd69ff4390` | `tz1LJmf4GUTrNsZVWXomSfqyWEWdNPo75Wz3` | `0x2fdc8fdc…1c34` |
+
+Re-verified live (eth_getLogs + eth_getTransactionByHash) on 2026-06-11; all three txs have
+`from = 0x7e20580000000000000000000000000000000001`. Note the first tx's `to` differs from the
+emitting alias — the handler keys on `log.address`, never `tx.to`.
+
+## Expected (GREEN)
+
+- `l2_account` has **exactly 3 rows**, one per vector;
+- each row: `kind = evm_alias`, `native_tz_address` = the decoded nativeAddress (incl. the
+  KT1 one), `initialized_at_level` / `initialized_at_tx` from the carrying transaction.
+
+## Run
+
+```bash
+make test-indexer CASE=alias_registry   # syncs ~4100 L2 blocks via the node (~30 min, node-bound)
+make inspect-test CASE=alias_registry
+```

--- a/tests/stand/cases/alias_registry/config.yaml
+++ b/tests/stand/cases/alias_registry/config.yaml
@@ -1,0 +1,79 @@
+# Standalone config for the alias-registry case. See README.md.
+# sqlite + oneshot (no tezos.head, last_level on every index).
+# Only the alias index runs; the L1 datasources exist because hooks/ServiceContainer
+# (on_restart/on_reindex) need tzkt/metadata/tezos_node/rollup_node regardless.
+
+spec_version: 3.0
+package: rollup_bridge_indexer
+
+
+database:
+  kind: sqlite
+  path: ${SQLITE_PATH:-/tmp/bridge_alias_registry.sqlite}
+
+
+datasources:
+  tzkt:
+    kind: tezos.tzkt
+    url: ${TZKT_URL}
+
+  metadata:
+    kind: tzip_metadata
+    network: ${NETWORK}
+    url: ${METADATA_URL}
+
+  tezos_node:
+    kind: http
+    url: ${TEZOS_NODE_URL}
+
+  etherlink_node:
+    kind: evm.node
+    url: ${ETHERLINK_NODE_URL}
+    http:
+      batch_size: 100
+      ratelimit_rate: 900
+      ratelimit_period: 60
+      ratelimit_sleep: 10
+
+  rollup_node:
+    kind: http
+    url: ${ROLLUP_NODE_URL}
+    http:
+      retry_count: 2
+      retry_sleep: 1.0
+      retry_multiplier: 1.0
+      connection_timeout: 1
+      request_timeout: 4
+
+
+contracts:
+  # TEZOSX_CALLER — kernel-only injector: synthetic `from` of all init_tezosx_alias txs
+  # (and other kernel-injected Tezos X calls, e.g. claim_xtz).
+  tezosx_caller:
+    kind: evm
+    address: '0x7e20580000000000000000000000000000000001'
+
+
+indexes:
+  # Alias registry: every Tezos X alias emits Initialized(string,bytes,uint256) once, from its
+  # own address — not wildcard-subscribable, so we filter txs by the kernel injector `from_`
+  # and parse receipt logs in the handler (handlers/etherlink/on_alias_initialized.py).
+  etherlink_alias_initialized_transactions:
+    kind: evm.transactions
+    first_level: ${L2_FIRST_LEVEL}
+    last_level: ${L2_LAST_LEVEL}
+    datasources:
+      - etherlink_node
+    handlers:
+      - callback: etherlink.on_alias_initialized
+        from_: tezosx_caller
+
+
+advanced:
+  unsafe_sqlite: true
+  reindex:
+    config_modified: ignore
+    schema_modified: ignore
+    migration: ignore
+    rollback: ignore
+    manual: wipe

--- a/tests/stand/cases/alias_registry/verify.py
+++ b/tests/stand/cases/alias_registry/verify.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Verdict for the alias-registry case: did all 3 previewnet Initialized events land in l2_account?"""
+
+from __future__ import annotations
+
+from tests.stand import verify_lib as lib
+
+# Golden vectors: every Initialized(string,bytes,uint256) event in previewnet history
+# (verified live via eth_getLogs + eth_getTransactionByHash on 2026-06-11).
+# alias address (40-hex, no 0x) -> (native_tz_address, initialized_at_level, initialized_at_tx)
+GOLDEN = {
+    '9adffdb184eae59204995cadfb57aafecc715d73': (
+        'KT19iqeZxnYDz6GbU67uwF4ECH7bY46WTV2v',  # KT1 native source: empty pubkey in the event
+        172338,
+        '61a1e6ec1e9092d662aaada1756298b81778c3b93068ce673801b9c2d826f499',
+    ),
+    '3f2e3819832be16420810dfafc813334698bfa65': (
+        'tz1ebDT2XwpwP6ja3ESuLUy8BgZwrmi1XpX3',
+        172570,
+        '0068f92ffeb3702939eecfd78187253295946f8afaa17cceb6abdf70f015c6e1',
+    ),
+    '93ee79eb06a7052f3d7f9c160b7927dd69ff4390': (
+        'tz1LJmf4GUTrNsZVWXomSfqyWEWdNPo75Wz3',
+        176345,
+        '2fdc8fdc6aeceb2ee379694ec353b0205bd27a621755f3a0949f9bd9b6811c34',
+    ),
+}
+
+
+def main() -> int:
+    conn = lib.open_db('/tmp/bridge_alias_registry.sqlite')
+    cur = conn.cursor()
+
+    lib.section('Row counts')
+    c = lib.count(cur, 'l2_account')
+    print(f'  {"l2_account":<22} {"(missing)" if c < 0 else c}')
+
+    lib.section('L2 accounts (l2_account) — the alias registry')
+    accounts = {
+        r['address']: r
+        for r in lib.rows(
+            cur,
+            'SELECT address, kind, native_tz_address, initialized_at_level, initialized_at_tx '
+            'FROM l2_account ORDER BY initialized_at_level LIMIT 20',
+        )
+    }
+    for r in accounts.values():
+        print(f'  {r["address"]} kind={r["kind"]} native={r["native_tz_address"]} lvl={r["initialized_at_level"]}')
+
+    v = lib.Verdict()
+    v.check(c == 3, 'exactly 3 l2_account rows (all Initialized events in previewnet history)')
+    for alias, (native, level, tx) in GOLDEN.items():
+        row = accounts.get(alias)
+        tag = native[:3] if native.startswith('tz') else 'KT1'
+        v.check(row is not None, f'alias {alias[:8]}… registered')
+        if row is None:
+            continue
+        v.check(row['kind'] == 'evm_alias', f'alias {alias[:8]}… kind=evm_alias')
+        v.check(row['native_tz_address'] == native, f'alias {alias[:8]}… native_tz_address is the {tag} source')
+        v.check(row['initialized_at_level'] == level, f'alias {alias[:8]}… initialized_at_level={level}')
+        v.check(row['initialized_at_tx'] == tx, f'alias {alias[:8]}… initialized_at_tx matches')
+    conn.close()
+    return v.report()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/stand/cases/alias_registry/window.env
+++ b/tests/stand/cases/alias_registry/window.env
@@ -1,0 +1,13 @@
+# Block window for the alias-registry case: all 3 Initialized events in previewnet history
+# (levels 172338, 172570, 176345 — verified live via eth_getLogs on 2026-06-11).
+
+# Etherlink L2 window (brackets all three alias-init txs)
+L2_FIRST_LEVEL=172300
+L2_LAST_LEVEL=176400
+
+# Rollup inbox-backfill window (on_restart) — irrelevant to this case, kept tiny so the
+# stripped test indexer doesn't backfill the whole shadownet inbox.
+ROLLUP_SYNC_FIRST_LEVEL=3599290
+ROLLUP_SYNC_LAST_LEVEL=3599300
+
+SQLITE_PATH=/tmp/bridge_alias_registry.sqlite


### PR DESCRIPTION
## Summary

- New `l2_account` table (`L2AccountKind`: `evm` / `tz` / `evm_alias`) — the alias registry mapping EVM aliases to their native Tezos addresses, so deposits to an alias / NAC-initiated withdrawals can be attributed to the tz-account instead of an opaque `0x` address.
- New transactions-kind index on tezosx-shadownet filtered by `from_ = TEZOSX_CALLER` (`0x7e2058…0001`): DipDup can't wildcard-subscribe `Initialized(string,bytes,uint256)` since it's emitted from every alias address, so the handler parses receipt logs by topic and upserts `L2Account` keyed by the emitting alias address. `nativePublicKey` is not stored; `Forwarded` events are not indexed.
- Stand case `alias_registry`: block window 172300–176400 covers all three `Initialized` events in previewnet history as golden vectors, including the KT1-native one (verified green, 16/16 checks).

Design rationale: `Initialized`-only indexing and the normalized `L2Account` table are the decided options from the knowledge-base decisions (alias-indexing-strategy → Option A, deposit-model-design → Option 3).

## Out of scope (follow-up PR)

- FK conversion of `l2_deposit` / `l2_withdrawal` `l2_account` columns onto `L2Account` + data migration.
- Bridge-matcher enrichment (`l1_account` from `native_tz_address` for `kind=evm_alias`).

## Notes for deploy

- New table changes the DipDup schema hash — existing DBs need `dipdup schema approve`.

Stacked on #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)