### PR TITLE
 Index TezosX aliases on EVM: minor fixes

### DIFF
--- a/handlers/bridge_matcher.py
+++ b/handlers/bridge_matcher.py
@@ -40,11 +40,18 @@ class BridgeMatcher:
         async for l1_deposit in qs:
             l1_deposit: TezosDepositOperation
             bridge_deposit = await BridgeDepositOperation.create(l1_transaction=l1_deposit)
+            # tz receiver -> Michelson L2, hex receiver -> EVM (known from the L1 routing).
+            runtime_kind = (
+                RuntimeKind.michelson
+                if l1_deposit.l2_account_id.startswith('tz')
+                else RuntimeKind.evm
+            )
             await BridgeOperation.create(
                 id=bridge_deposit.id,
                 type=BridgeOperationType.deposit,
                 l1_account=l1_deposit.l1_account,
                 l2_account_id=l1_deposit.l2_account_id,
+                runtime_kind=runtime_kind,
                 created_at=l1_deposit.timestamp,
                 updated_at=l1_deposit.timestamp,
                 status=BridgeOperationStatus.created,

--- a/handlers/etherlink/on_deposit.py
+++ b/handlers/etherlink/on_deposit.py
@@ -12,10 +12,11 @@ from rollup_bridge_indexer.models import TezosTicket
 from rollup_bridge_indexer.types.kernel.evm_events.deposit import DepositPayload
 
 
-async def _validate_ticket(ticket_hash):
+async def _validate_ticket(ticket_hash) -> TezosTicket:
     tezos_ticket = await TezosTicket.get_or_none(pk=ticket_hash)
     if tezos_ticket is None:
         raise ValueError('Ticket with given `ticket_hash` not found: {}', ticket_hash)
+    return tezos_ticket
 
 
 async def register_etherlink_token(token_contract: str, ticket_hash: int) -> EtherlinkToken:
@@ -24,13 +25,17 @@ async def register_etherlink_token(token_contract: str, ticket_hash: int) -> Eth
     if etherlink_token:
         return etherlink_token
 
-    await _validate_ticket(ticket_hash)
+    tezos_ticket = await _validate_ticket(ticket_hash)
     if await EtherlinkToken.filter(ticket_id=ticket_hash).exclude(id=token_contract).count():
         raise ValueError('Specified `proxy` contract address not whitelisted: {}', token_contract)
 
+    l1_token = await tezos_ticket.token
     return await EtherlinkToken.create(
         id=token_contract,
         ticket_id=ticket_hash,
+        name=l1_token.name,
+        symbol=l1_token.symbol,
+        decimals=l1_token.decimals,
     )
 
 

--- a/models/enum.py
+++ b/models/enum.py
@@ -25,8 +25,7 @@ class OriginKind(Enum):
 
 
 class RuntimeKind(Enum):
-    # The L2 runtime that processed the operation — the honest discriminator that
-    # replaced the matcher's `transaction_hash`-prefix / inbox-coords-null heuristics.
+    # The L2 runtime that processed the operation.
     # evm = the EVM rollup runtime (real txs, wei-denominated, 0x receivers);
     # michelson = the Tezos X Michelson runtime (synthetic tz-receiver deposits,
     # mutez-denominated). Distinct from OriginKind, which classifies the *address*. Also

--- a/tests/stand/cases/alias_deposit/README.md
+++ b/tests/stand/cases/alias_deposit/README.md
@@ -10,6 +10,11 @@ Live data, alias `0x21ab…bc21` → `tz1ekkz…Vydc` (already initialized on-ch
 indexed). Exact blocks/amounts in `window.env`; asserted vectors in `verify.py`. Three deposits —
 two XTZ and one FA — all resolved to the native origin.
 
+It also doubles as a regression guard for an **unrelated** bug: the FA `l2_deposit`'s
+`etherlink_token` must inherit L1 metadata (name/symbol/decimals) instead of the model defaults
+(null/null/0). That check lives here only because this is the sole stand case exercising the FA
+`register_etherlink_token` path — it is not about alias resolution.
+
 ```bash
 make test-indexer CASE=alias_deposit && make inspect-test CASE=alias_deposit
 ```

--- a/tests/stand/cases/alias_deposit/verify.py
+++ b/tests/stand/cases/alias_deposit/verify.py
@@ -27,12 +27,21 @@ def main() -> int:
     deposits = lib.dump(cur, 'l2_deposit', 'level, l2_account_id, amount, token_id', order_by='level')
     seen = {(r['amount'], r['token_id']) for r in deposits}
 
+    # Independent regression (NOT alias-related): this case happens to index an FA deposit, so it
+    # also guards that the FA L2 proxy token inherits L1 metadata via register_etherlink_token
+    # (model defaults are symbol null / decimals 0). It lives here only because this is the sole
+    # stand case exercising the FA Deposit path.
+    fa_token = lib.dump(cur, 'etherlink_token', 'id, symbol, decimals')
+    fa = next((r for r in fa_token if r['id'] == FA_TOKEN), None)
+
     v = lib.Verdict()
     v.check(len(deposits) >= 3, 'three deposits (2 XTZ + 1 FA) indexed')
     v.check_alias(accounts, ALIAS, NATIVE)
     v.check(bool(deposits) and all(r['l2_account_id'] == ALIAS for r in deposits), 'every deposit keyed on the alias runtime address')
     for amount, token, label in EXPECTED:
         v.check((amount, token) in seen, f'deposit present: {label}')
+    v.check(fa is not None and fa['decimals'] == 6, 'FA L2 token decimals mirror L1 (6, not default 0)')
+    v.check(fa is not None and fa['symbol'] is not None, 'FA L2 token symbol populated from L1 (not null)')
     return v.report()
 
 

--- a/tests/stand/cases/evm_feed_deposit/verify.py
+++ b/tests/stand/cases/evm_feed_deposit/verify.py
@@ -18,10 +18,10 @@ def main() -> int:
     lib.section('L2 deposits (l2_deposit) — the Tezos->EVM side')
     for r in lib.rows(
         cur,
-        'SELECT level, l2_account, amount, token_id, inbox_message_level, inbox_message_index FROM l2_deposit ORDER BY level LIMIT 20',
+        'SELECT level, l2_account_id, amount, token_id, inbox_message_level, inbox_message_index FROM l2_deposit ORDER BY level LIMIT 20',
     ):
         print(
-            f'  lvl={r["level"]} l2={r["l2_account"]} amount={r["amount"]} token={r["token_id"]} '
+            f'  lvl={r["level"]} l2={r["l2_account_id"]} amount={r["amount"]} token={r["token_id"]} '
             f'inbox=({r["inbox_message_level"]},{r["inbox_message_index"]})'
         )
 

--- a/tests/stand/cases/inbox_backfill_first_level/verify.py
+++ b/tests/stand/cases/inbox_backfill_first_level/verify.py
@@ -38,9 +38,9 @@ def main() -> int:
         print(f'  ({r["level"]}, {r["index"]})')
 
     lib.section('L1 deposits (l1_deposit)')
-    l1 = lib.rows(cur, 'SELECT level, l2_account, amount FROM l1_deposit ORDER BY level')
+    l1 = lib.rows(cur, 'SELECT level, l2_account_id, amount FROM l1_deposit ORDER BY level')
     for r in l1:
-        print(f'  lvl={r["level"]} l2={r["l2_account"]} amount={r["amount"]}')
+        print(f'  lvl={r["level"]} l2={r["l2_account_id"]} amount={r["amount"]}')
 
     lib.section('bridge_deposit inbox attach')
     bridge = lib.rows(
@@ -60,7 +60,7 @@ def main() -> int:
     # The deposit itself indexed as expected.
     v.check(len(l1) == 1, 'exactly one L1 deposit indexed')
     v.check(bool(l1) and l1[0]['level'] == DEPOSIT_LEVEL, f'l1_deposit at level {DEPOSIT_LEVEL}')
-    v.check(bool(l1) and l1[0]['l2_account'] == RECEIVER, f'l1_deposit.l2_account is {RECEIVER}')
+    v.check(bool(l1) and l1[0]['l2_account_id'] == RECEIVER, f'l1_deposit.l2_account_id is {RECEIVER}')
     v.check(bool(l1) and l1[0]['amount'] == AMOUNT_MUTEZ, f'l1_deposit.amount is {AMOUNT_MUTEZ}')
     # Downstream effect: parameters-hash attach worked, the deposit is matchable.
     v.check(

--- a/tests/stand/cases/michelson_l2_deposit/verify.py
+++ b/tests/stand/cases/michelson_l2_deposit/verify.py
@@ -20,8 +20,8 @@ def main() -> int:
         print(f'  {t:<22} {"(missing)" if c < 0 else c}')
 
     lib.section('L1 deposits (l1_deposit)')
-    for r in lib.rows(cur, 'SELECT level, l1_account, l2_account, amount FROM l1_deposit ORDER BY level LIMIT 20'):
-        print(f'  lvl={r["level"]} l1={r["l1_account"]} l2={r["l2_account"]} amount={r["amount"]}')
+    for r in lib.rows(cur, 'SELECT level, l1_account, l2_account_id, amount FROM l1_deposit ORDER BY level LIMIT 20'):
+        print(f'  lvl={r["level"]} l1={r["l1_account"]} l2={r["l2_account_id"]} amount={r["amount"]}')
 
     lib.section('bridge_operation (deposit side)')
     matched = lib.rows(

--- a/tests/stand/cases/michelson_l2_deposit_ophash/verify.py
+++ b/tests/stand/cases/michelson_l2_deposit_ophash/verify.py
@@ -53,33 +53,33 @@ def main() -> int:
         print(f'  {t:<22} {"(missing)" if c < 0 else c}')
 
     lib.section('L1 deposits (l1_deposit)')
-    l1 = lib.rows(cur, 'SELECT level, l1_account, l2_account, amount FROM l1_deposit ORDER BY level')
+    l1 = lib.rows(cur, 'SELECT level, l1_account, l2_account_id, amount FROM l1_deposit ORDER BY level')
     for r in l1:
-        print(f'  lvl={r["level"]} l1={r["l1_account"]} l2={r["l2_account"]} amount={r["amount"]}')
+        print(f'  lvl={r["level"]} l1={r["l1_account"]} l2={r["l2_account_id"]} amount={r["amount"]}')
 
     lib.section('L2 Michelson deposits (l2_deposit)')
     l2 = lib.rows(
         cur,
-        'SELECT level, transaction_hash, l2_account, amount, token_id, ticket_hash, '
+        'SELECT level, transaction_hash, l2_account_id, amount, token_id, ticket_hash, '
         'inbox_message_level, inbox_message_index FROM l2_deposit ORDER BY level',
     )
     for r in l2:
         print(
-            f'  lvl={r["level"]} op={r["transaction_hash"]} l2={r["l2_account"]} amount={r["amount"]} '
+            f'  lvl={r["level"]} op={r["transaction_hash"]} l2={r["l2_account_id"]} amount={r["amount"]} '
             f'token={r["token_id"]} inbox=({r["inbox_message_level"]},{r["inbox_message_index"]})'
         )
 
     lib.section('bridge_operation (matcher output)')
     bridge = lib.rows(
         cur,
-        'SELECT bo.status, bo.type, bo.is_completed, bo.is_successful, bo.l2_account, '
+        'SELECT bo.status, bo.type, bo.is_completed, bo.is_successful, bo.l2_account_id, '
         'bd.l1_transaction_id IS NOT NULL AS has_l1, bd.l2_transaction_id IS NOT NULL AS has_l2 '
         'FROM bridge_deposit bd JOIN bridge_operation bo ON bo.id = bd.id ORDER BY bo.created_at',
     )
     for r in bridge:
         print(
             f'  status={r["status"]} type={r["type"]} completed={bool(r["is_completed"])} '
-            f'ok={bool(r["is_successful"])} l2={r["l2_account"]} l1_leg={bool(r["has_l1"])} l2_leg={bool(r["has_l2"])}'
+            f'ok={bool(r["is_successful"])} l2={r["l2_account_id"]} l1_leg={bool(r["has_l1"])} l2_leg={bool(r["has_l2"])}'
         )
 
     expected = _reconstructed_op_hashes(cur)
@@ -90,7 +90,7 @@ def main() -> int:
     v = lib.Verdict()
     # L1 leg: indexed and routed to the real tz1 receiver (l2_account fix).
     v.check(len(l1) == 1, 'exactly one L1 deposit indexed')
-    v.check(bool(l1) and l1[0]['l2_account'] == RECEIVER, f'l1_deposit.l2_account is the tz1 receiver ({RECEIVER})')
+    v.check(bool(l1) and l1[0]['l2_account_id'] == RECEIVER, f'l1_deposit.l2_account_id is the tz1 receiver ({RECEIVER})')
     # L2 leg: full consumer-visible row — xtz_michelson token, mutez amount.
     v.check(len(l2) == 1, 'exactly one L2 Michelson deposit indexed')
     v.check(bool(l2) and l2[0]['transaction_hash'] == L2_OP_HASH, 'L2 row carries the synthetic op-hash')
@@ -105,7 +105,7 @@ def main() -> int:
         any(r['status'] == 'FINISHED' and bool(r['has_l1']) and bool(r['has_l2']) for r in bridge),
         'bridge_operation FINISHED with both legs (production matcher)',
     )
-    v.check(any(r['l2_account'] == RECEIVER for r in bridge), 'bridge_operation.l2_account is the tz1 receiver')
+    v.check(any(r['l2_account_id'] == RECEIVER for r in bridge), 'bridge_operation.l2_account_id is the tz1 receiver')
     # Secondary: the derivation itself still reproduces the L2 op-hash.
     v.check(L2_OP_HASH in expected, 'inbox row reconstructs to the expected op-hash (derivation sane)')
     conn.close()

--- a/tests/stand/verify_lib.py
+++ b/tests/stand/verify_lib.py
@@ -98,10 +98,10 @@ class Verdict:
         return bool(ok)
 
     def check_alias(self, accounts: dict[str, sqlite3.Row], alias: str, native: str) -> None:
-        """Assert the alias `l2_account` row exists and resolved to `native` (kind=evm_alias)."""
+        """Assert the alias `l2_account` row exists and resolved to `native` (kind=alias)."""
         row = accounts.get(alias)
         self.check(row is not None, f'l2_account row exists for alias {alias}')
-        self.check(row is not None and row['kind'] == 'evm_alias', 'alias resolved: kind == evm_alias')
+        self.check(row is not None and row['kind'] == 'alias', 'alias resolved: kind == alias')
         self.check(row is not None and row['origin'] == native, f'alias resolved: origin == {native}')
 
     def report(self) -> int:


### PR DESCRIPTION
- [x] FA L2 tokens: populate `name`/`symbol`/`decimals` from the L1 ticket
- [x] Matcher: set a deposit's `runtime_kind` at creation from the routing receiver
- [x] Update stand verifiers for the L2 model rename