### PR TITLE
fix(rollup): stop losing rollup messages on a lagging node and across restarts

### DIFF
--- a/handlers/rollup_message.py
+++ b/handlers/rollup_message.py
@@ -184,13 +184,25 @@ class OutboxMessageService:
 
 
 class RollupMessageIndex:
+    """Indexes the rollup inbox from TzKT and the outbox from the rollup node.
+
+    One pass is `_process`. The inbox is walked with a cursor; every `external` message means
+    its L1 level has outbox messages to fetch, and that level goes into `_outbox_level_queue`.
+
+    The queue is the one piece of that work the cursor cannot describe — the level of a full
+    outbox's continuation has no inbox message behind it at all — so it is stored alongside the
+    rows, in `dipdup_meta`. Two orderings make it durable: it is written **before** the inbox
+    rows that move the cursor past the externals that filled it, and a level leaves it **after**
+    the outbox rows it produced are committed. Between those two points a crash costs a re-fetch
+    and never a message.
+    """
+
     first_ticket_level: int | None = None
     request_limit = 10000
     _lock = threading.Lock()
 
-    # Where the pending outbox levels live between runs. `dipdup_meta` is DipDup's own
-    # key-value table, not part of the package schema, so using it costs no schema hash
-    # change (and therefore no reindex).
+    # Not part of the package schema, so storing here costs no schema hash change — and
+    # therefore no reindex.
     pending_outbox_levels_key = 'rollup_message_pending_outbox_levels'
 
     def __init__(
@@ -265,77 +277,88 @@ class RollupMessageIndex:
                     BridgeMatcherLocks.set_pending_claimed_fast_withdrawals()
 
     async def _process(self):
-        # Levels a previous run queued but never stored: the inbox cursor has already moved
-        # past the external messages that queued them, so nothing else will ask again.
         await self._drain_outbox_levels()
 
-        inbox = await self._tzkt.request(
-            method='GET',
-            url=f'v1/smart_rollups/inbox?id.gt={self._inbox_id_cursor}&type.in=transfer,external&micheline=0&sort=id&limit={self.request_limit}',
-        )
-
-        if len(inbox) == 0:
+        inbox = await self._fetch_inbox_page()
+        if not inbox:
             if self._status == IndexStatus.syncing:
                 self._status = IndexStatus.realtime
                 return
         else:
-            self._logger.info('Found %d not indexed Inbox Messages.', len(inbox))
-
-            for inbox_message in inbox:
-                # Test-only upper bound: stop once we pass the requested window.
-                if self._sync_last_level is not None and inbox_message['level'] > self._sync_last_level:
-                    self._status = IndexStatus.realtime
-                    break
-                match inbox_message['type']:
-                    case RollupInboxMessageType.transfer.value:
-                        # Validate that transfer messages always have a target field
-                        if 'target' not in inbox_message or 'address' not in inbox_message.get('target', {}):
-                            raise ValueError(f"Transfer inbox message {inbox_message['id']} is missing target field")
-
-                        # Filter by target rollup (TzKT API doesn't support target= parameter)
-                        if inbox_message['target']['address'] != self._bridge.smart_rollup_address:
-                            continue
-
-                        await self._handle_transfer_inbox_message(inbox_message)
-                    case RollupInboxMessageType.external.value:
-                        await self._handle_external_inbox_message(inbox_message)
-                    case _:
-                        continue
-                self._inbox_id_cursor = inbox_message['id']
-
-            # Durability point: the queue must reach the database BEFORE the inbox rows that
-            # move the resume cursor past the external messages that filled it. Otherwise a
-            # failure in the drain below leaves work that is owed but no longer reachable.
-            await self._save_pending_outbox_levels()
-
-            if len(self._create_inbox_batch):
-                await RollupInboxMessage.bulk_create(self._create_inbox_batch)
-                self._logger.info('Successfully saved %d new Inbox Messages.', len(self._create_inbox_batch))
-                self._inbox_level_cursor = self._create_inbox_batch[-1].level
-                BridgeMatcherLocks.set_pending_inbox()
-                # A late-arriving inbox message may complete an already-recorded L2
-                # Michelson deposit — re-trigger the op-hash matcher step too.
-                BridgeMatcherLocks.set_pending_michelson_deposits()
-
-                del self._create_inbox_batch[:]
+            await self._walk_inbox_page(inbox)
+            await self._commit_inbox_page()
 
         await self._drain_outbox_levels()
+        await self._write_cursor_sentinel()
 
+    async def _fetch_inbox_page(self):
+        """The messages after the cursor. `id.gt=` — the cursor is the last id already consumed."""
+        inbox = await self._tzkt.request(
+            method='GET',
+            url=f'v1/smart_rollups/inbox?id.gt={self._inbox_id_cursor}&type.in=transfer,external&micheline=0&sort=id&limit={self.request_limit}',
+        )
+        if len(inbox):
+            self._logger.info('Found %d not indexed Inbox Messages.', len(inbox))
+        return inbox
+
+    async def _walk_inbox_page(self, inbox):
+        """Sort the page into the two in-memory batches. Nothing here touches the database."""
+        for inbox_message in inbox:
+            # Test-only upper bound: stop once we pass the requested window.
+            if self._sync_last_level is not None and inbox_message['level'] > self._sync_last_level:
+                self._status = IndexStatus.realtime
+                break
+            match inbox_message['type']:
+                case RollupInboxMessageType.transfer.value:
+                    if 'target' not in inbox_message or 'address' not in inbox_message.get('target', {}):
+                        raise ValueError(f"Transfer inbox message {inbox_message['id']} is missing target field")
+                    # TzKT has no `target=` filter, so the rollup is selected here.
+                    if inbox_message['target']['address'] != self._bridge.smart_rollup_address:
+                        continue
+                    await self._handle_transfer_inbox_message(inbox_message)
+                case RollupInboxMessageType.external.value:
+                    await self._handle_external_inbox_message(inbox_message)
+                case _:
+                    continue
+            self._inbox_id_cursor = inbox_message['id']
+
+    async def _commit_inbox_page(self):
+        """Store the pending outbox levels, then the rows — in that order.
+
+        The rows move the resume cursor past the external messages that filled the queue, so a
+        queue stored after them would describe work that nothing can reach again.
+        """
+        await self._save_pending_outbox_levels()
+
+        if not len(self._create_inbox_batch):
+            return
+        await RollupInboxMessage.bulk_create(self._create_inbox_batch)
+        self._logger.info('Successfully saved %d new Inbox Messages.', len(self._create_inbox_batch))
+        self._inbox_level_cursor = self._create_inbox_batch[-1].level
+        BridgeMatcherLocks.set_pending_inbox()
+        # A late-arriving inbox message may complete an already-recorded L2 Michelson deposit.
+        BridgeMatcherLocks.set_pending_michelson_deposits()
+
+        del self._create_inbox_batch[:]
+
+    async def _write_cursor_sentinel(self):
+        """Mark the cursor with a level-0 row when no real message carries its id."""
         self._logger.info('Update Inbox Message cursor index to %s', self._inbox_id_cursor)
-        if not await RollupInboxMessage.exists(id=self._inbox_id_cursor):
-            await RollupInboxMessage.filter(
-                level=0,
-                type=RollupInboxMessageType.external.value,
-                id__lt=self._inbox_id_cursor,
-            ).delete()
-            await RollupInboxMessage.create(
-                id=self._inbox_id_cursor,
-                level=0,
-                index=0,
-                message={},
-                parameters_hash=None,
-                type=RollupInboxMessageType.external,
-            )
+        if await RollupInboxMessage.exists(id=self._inbox_id_cursor):
+            return
+        await RollupInboxMessage.filter(
+            level=0,
+            type=RollupInboxMessageType.external.value,
+            id__lt=self._inbox_id_cursor,
+        ).delete()
+        await RollupInboxMessage.create(
+            id=self._inbox_id_cursor,
+            level=0,
+            index=0,
+            message={},
+            parameters_hash=None,
+            type=RollupInboxMessageType.external,
+        )
 
     async def _drain_outbox_levels(self):
         """Fetch every pending outbox level the chain has already reached, then store the result.
@@ -420,8 +443,6 @@ class RollupMessageIndex:
         )
 
     async def _handle_external_inbox_message(self, message):
-        # In-memory only here; `_process` stores the queue before the inbox rows of this page
-        # move the resume cursor past this message.
         self._outbox_level_queue.add(message['level'])
 
     async def _handle_outbox_level(self, outbox_level):

--- a/handlers/rollup_message.py
+++ b/handlers/rollup_message.py
@@ -484,7 +484,9 @@ class RollupMessageIndex:
 
         try:
             last_saved_inbox_message = await RollupInboxMessage.all().order_by('-id').first()
-            self._inbox_id_cursor = 1 + last_saved_inbox_message.id
+            # The cursor is the last id consumed — `id.gt=` resumes strictly after it, so the
+            # saved row is not re-read and the one behind it is not skipped.
+            self._inbox_id_cursor = last_saved_inbox_message.id
             self._logger.info('Last previous saved Inbox Message found. Going to continue with next Inbox Message.')
             await self._load_pending_outbox_levels()
         except AttributeError:
@@ -508,7 +510,9 @@ class RollupMessageIndex:
                 method='GET',
                 url=f'v1/smart_rollups/inbox?type.in=transfer,external&level.ge={first_level}&sort.asc=id&limit=1',
             )
-            self._inbox_id_cursor = inbox[0]['id']
+            # ...which is the first message to index, not one already indexed: step back so the
+            # cursor keeps meaning the same thing.
+            self._inbox_id_cursor = inbox[0]['id'] - 1
 
         self._logger.info('Inbox Message cursor index is %d.', self._inbox_id_cursor)
         self._status = IndexStatus.syncing

--- a/handlers/rollup_message.py
+++ b/handlers/rollup_message.py
@@ -11,6 +11,7 @@ from uuid import uuid5
 import aiohttp
 import orjson
 from dipdup.models import IndexStatus
+from dipdup.models import Meta
 from pydantic import BaseModel
 from pydantic import ValidationError
 from pytezos import MichelsonRuntimeError
@@ -187,6 +188,11 @@ class RollupMessageIndex:
     request_limit = 10000
     _lock = threading.Lock()
 
+    # Where the pending outbox levels live between runs. `dipdup_meta` is DipDup's own
+    # key-value table, not part of the package schema, so using it costs no schema hash
+    # change (and therefore no reindex).
+    pending_outbox_levels_key = 'rollup_message_pending_outbox_levels'
+
     def __init__(
         self,
         tzkt: TezosTzktDatasource,
@@ -220,6 +226,9 @@ class RollupMessageIndex:
         self._sync_last_level: int | None = int(_sync_last) if _sync_last else None
 
         self._outbox_level_queue: set = set()
+        # Last value written to `dipdup_meta`; keeps the durability write off the hot path
+        # when the queue has not moved. `None` means "not read from the database yet".
+        self._saved_outbox_level_queue: set[int] | None = None
         self._create_inbox_batch: list[RollupInboxMessage] = []
         self._create_outbox_batch: list[RollupOutboxMessage] = []
 
@@ -256,6 +265,10 @@ class RollupMessageIndex:
                     BridgeMatcherLocks.set_pending_claimed_fast_withdrawals()
 
     async def _process(self):
+        # Levels a previous run queued but never stored: the inbox cursor has already moved
+        # past the external messages that queued them, so nothing else will ask again.
+        await self._drain_outbox_levels()
+
         inbox = await self._tzkt.request(
             method='GET',
             url=f'v1/smart_rollups/inbox?id.gt={self._inbox_id_cursor}&type.in=transfer,external&micheline=0&sort=id&limit={self.request_limit}',
@@ -290,6 +303,11 @@ class RollupMessageIndex:
                         continue
                 self._inbox_id_cursor = inbox_message['id']
 
+            # Durability point: the queue must reach the database BEFORE the inbox rows that
+            # move the resume cursor past the external messages that filled it. Otherwise a
+            # failure in the drain below leaves work that is owed but no longer reachable.
+            await self._save_pending_outbox_levels()
+
             if len(self._create_inbox_batch):
                 await RollupInboxMessage.bulk_create(self._create_inbox_batch)
                 self._logger.info('Successfully saved %d new Inbox Messages.', len(self._create_inbox_batch))
@@ -301,20 +319,7 @@ class RollupMessageIndex:
 
                 del self._create_inbox_batch[:]
 
-        while len(self._outbox_level_queue) > 0 and (
-            self._status == IndexStatus.syncing or min(self._outbox_level_queue) <= self._realtime_head_level
-        ):
-            outbox_level = self._outbox_level_queue.pop()
-            await self._handle_outbox_level(outbox_level)
-
-        if len(self._create_outbox_batch):
-            await RollupOutboxMessage.bulk_create(self._create_outbox_batch, ignore_conflicts=True)
-            self._logger.info('Successfully saved %d new Outbox Messages.', len(self._create_outbox_batch))
-            self._outbox_index_cursor = self._create_outbox_batch[-1].index
-            self._outbox_level_cursor = self._create_outbox_batch[-1].level
-            BridgeMatcherLocks.set_pending_outbox()
-
-            del self._create_outbox_batch[:]
+        await self._drain_outbox_levels()
 
         self._logger.info('Update Inbox Message cursor index to %s', self._inbox_id_cursor)
         if not await RollupInboxMessage.exists(id=self._inbox_id_cursor):
@@ -331,6 +336,68 @@ class RollupMessageIndex:
                 parameters_hash=None,
                 type=RollupInboxMessageType.external,
             )
+
+    async def _drain_outbox_levels(self):
+        """Fetch every pending outbox level the chain has already reached, then store the result.
+
+        A level leaves the pending set only once its messages are committed: the fetch can
+        fail (a wedged rollup node answers 500 for every level above the one it processed),
+        and until the rows are in the database the pending level is the only record that the
+        work is still owed.
+        """
+        while len(self._outbox_level_queue) > 0 and min(self._outbox_level_queue) <= self._realtime_head_level:
+            # Lowest first: the loop condition speaks about the lowest level, so the drain has
+            # to take that one. Popping an arbitrary element can reach above the head.
+            outbox_level = min(self._outbox_level_queue)
+            self._outbox_level_queue.discard(outbox_level)
+            await self._handle_outbox_level(outbox_level)
+
+        if len(self._create_outbox_batch):
+            await RollupOutboxMessage.bulk_create(self._create_outbox_batch, ignore_conflicts=True)
+            self._logger.info('Successfully saved %d new Outbox Messages.', len(self._create_outbox_batch))
+            self._outbox_index_cursor = self._create_outbox_batch[-1].index
+            self._outbox_level_cursor = self._create_outbox_batch[-1].level
+            BridgeMatcherLocks.set_pending_outbox()
+
+            del self._create_outbox_batch[:]
+
+        # The drained levels are rows now; what is left is what is still deferred or owed.
+        await self._save_pending_outbox_levels()
+
+    async def _load_pending_outbox_levels(self):
+        """Take over the outbox levels the previous run queued but never stored."""
+        meta = await Meta.get_or_none(key=self.pending_outbox_levels_key)
+        pending = {int(level) for level in (meta.value or [])} if meta else set()
+        self._saved_outbox_level_queue = set(pending)
+        if pending:
+            # A backfill page can leave thousands of levels pending — log the span, not the list.
+            self._logger.info('Restored %d pending Outbox level(s) from the previous run: %d..%d', len(pending), min(pending), max(pending))
+        self._outbox_level_queue |= pending
+
+    async def _drop_pending_outbox_levels(self):
+        """Forget levels owed to a database that no longer exists.
+
+        `dipdup_meta` is immune to the reindex wipe, so without this a fresh backfill would
+        inherit the previous history's queue and drag its outbox cursor ahead of itself.
+        """
+        deleted = await Meta.filter(key=self.pending_outbox_levels_key).delete()
+        if deleted:
+            self._logger.info('Dropped the pending Outbox levels of a wiped database.')
+        self._saved_outbox_level_queue = set()
+
+    async def _save_pending_outbox_levels(self):
+        """Persist the queue itself — the only piece of the drain the inbox cursor cannot describe.
+
+        The full-outbox continuation level (`_handle_outbox_level`, `outbox_level + 1`) has no
+        inbox message behind it at all, so it can only be recovered from here.
+        """
+        if self._outbox_level_queue == self._saved_outbox_level_queue:
+            return
+        await Meta.update_or_create(
+            key=self.pending_outbox_levels_key,
+            defaults={'value': sorted(self._outbox_level_queue)},
+        )
+        self._saved_outbox_level_queue = set(self._outbox_level_queue)
 
     async def _handle_transfer_inbox_message(self, message):
         try:
@@ -353,6 +420,8 @@ class RollupMessageIndex:
         )
 
     async def _handle_external_inbox_message(self, message):
+        # In-memory only here; `_process` stores the queue before the inbox rows of this page
+        # move the resume cursor past this message.
         self._outbox_level_queue.add(message['level'])
 
     async def _handle_outbox_level(self, outbox_level):
@@ -402,14 +471,26 @@ class RollupMessageIndex:
 
         if len(outbox) == self._protocol.smart_rollup_max_outbox_messages_per_level:
             self._logger.info('Full outbox found at level %d, going to check next level for the rest Outbox Messages...', outbox_level)
+            # No inbox message stands behind this level — the stored queue is its only record.
             self._outbox_level_queue.add(outbox_level + 1)
 
     async def _prepare_new_index(self):
+        # The drain refuses levels the chain has not reached yet. Until the first realtime head
+        # arrives that ceiling is 0, which would hold back the whole backfill — so take the head
+        # once here. It also keeps a restored continuation level from being asked for before the
+        # rollup node can answer for it.
+        head_data = await self._tzkt.get_head_block()
+        self._realtime_head_level = max(self._realtime_head_level, head_data.level)
+
         try:
             last_saved_inbox_message = await RollupInboxMessage.all().order_by('-id').first()
             self._inbox_id_cursor = 1 + last_saved_inbox_message.id
             self._logger.info('Last previous saved Inbox Message found. Going to continue with next Inbox Message.')
+            await self._load_pending_outbox_levels()
         except AttributeError:
+            # No inbox rows: this database was wiped or is brand new. `dipdup_meta` survives a
+            # reindex, so a stored queue here belongs to a history that no longer exists.
+            await self._drop_pending_outbox_levels()
             if self._sync_first_level is not None:
                 self._logger.info(
                     'No previous saved Inbox Message found. TEST bound: start indexing since level %d.', self._sync_first_level

--- a/handlers/rollup_message.py
+++ b/handlers/rollup_message.py
@@ -227,7 +227,6 @@ class RollupMessageIndex:
         self._inbox_level_cursor: int = 0
         self._outbox_level_cursor: int = 0
         self._outbox_index_cursor: int = 0
-        self._realtime_head_level: int = 0
         self._origination_level: int | None = None
 
         # Test-only inbox-backfill window (prod leaves these unset -> full backfill from origination).
@@ -268,7 +267,6 @@ class RollupMessageIndex:
     async def handle_realtime(self, head_level: int):
         with self._lock:
             if self._status == IndexStatus.realtime:
-                self._realtime_head_level = max(self._realtime_head_level, head_level)
                 previous_outbox_level_cursor = self._outbox_level_cursor
                 await self._process()
                 if self._outbox_level_cursor > previous_outbox_level_cursor:
@@ -361,19 +359,21 @@ class RollupMessageIndex:
         )
 
     async def _drain_outbox_levels(self):
-        """Fetch every pending outbox level the chain has already reached, then store the result.
+        """Fetch every pending outbox level the rollup node has already applied, then store the result.
 
         A level leaves the pending set only once its messages are committed: the fetch can
         fail (a wedged rollup node answers 500 for every level above the one it processed),
         and until the rows are in the database the pending level is the only record that the
         work is still owed.
         """
-        while len(self._outbox_level_queue) > 0 and min(self._outbox_level_queue) <= self._realtime_head_level:
-            # Lowest first: the loop condition speaks about the lowest level, so the drain has
-            # to take that one. Popping an arbitrary element can reach above the head.
-            outbox_level = min(self._outbox_level_queue)
-            self._outbox_level_queue.discard(outbox_level)
-            await self._handle_outbox_level(outbox_level)
+        if len(self._outbox_level_queue):
+            processed_level = await self._rollup_processed_level()
+            while len(self._outbox_level_queue) > 0 and min(self._outbox_level_queue) <= processed_level:
+                # Lowest first: the loop condition speaks about the lowest level, so the drain
+                # has to take that one. Popping an arbitrary element can reach above the ceiling.
+                outbox_level = min(self._outbox_level_queue)
+                self._outbox_level_queue.discard(outbox_level)
+                await self._handle_outbox_level(outbox_level)
 
         if len(self._create_outbox_batch):
             await RollupOutboxMessage.bulk_create(self._create_outbox_batch, ignore_conflicts=True)
@@ -386,6 +386,15 @@ class RollupMessageIndex:
 
         # The drained levels are rows now; what is left is what is still deferred or owed.
         await self._save_pending_outbox_levels()
+
+    async def _rollup_processed_level(self) -> int:
+        """The last L1 level the rollup node has applied — the ceiling the drain may ask for.
+
+        Not the L1 head: a node that stops applying blocks keeps answering RPC, and every level
+        above the one it applied has no hash it can resolve. That is the fault this ceiling is
+        for, and the L1 head does not see it.
+        """
+        return int(await self._rollup_node.request(method='GET', url='global/block/head/level'))
 
     async def _load_pending_outbox_levels(self):
         """Take over the outbox levels the previous run queued but never stored."""
@@ -496,13 +505,6 @@ class RollupMessageIndex:
             self._outbox_level_queue.add(outbox_level + 1)
 
     async def _prepare_new_index(self):
-        # The drain refuses levels the chain has not reached yet. Until the first realtime head
-        # arrives that ceiling is 0, which would hold back the whole backfill — so take the head
-        # once here. It also keeps a restored continuation level from being asked for before the
-        # rollup node can answer for it.
-        head_data = await self._tzkt.get_head_block()
-        self._realtime_head_level = max(self._realtime_head_level, head_data.level)
-
         try:
             last_saved_inbox_message = await RollupInboxMessage.all().order_by('-id').first()
             # The cursor is the last id consumed — `id.gt=` resumes strictly after it, so the

--- a/tests/stand/cases/outbox_fetch_failure/README.md
+++ b/tests/stand/cases/outbox_fetch_failure/README.md
@@ -144,15 +144,6 @@ a RECOVERY that is really a clean CONTROL run.
   when a level is filled to `smart_rollup_max_outbox_messages_per_level`). Both levels of this
   window carry exactly 1 message, so that branch never fires — and a level queued by *it*, not
   by an inbox message, has no inbox id protecting it at all.
-- **The cursor off-by-one** at `rollup_message.py:487`: the restart resumes at `1 + last saved
-  id` and then queries `id.gt=` that value, so the message at `last saved id + 1` is skipped
-  entirely; `:511` seeds the same cursor from the first message of a fresh window and drops
-  that one. Raw TzKT ids are contiguous and the `type.in=transfer,external` filter only breaks
-  the run at level boundaries, so the skipped position holds a real message in 88% of cursor
-  positions. Visible in the arms' facts (CONTROL's sentinel lands on 38278430, RECOVERY's on
-  38278431) but not asserted, and this case's own fixture rides on it: `CASE_SENTINEL_SEED_ID`
-  is one below the page's first external, which the restart arms therefore drop. Neither
-  affects the verdict — `CASE_EXTERNAL_IDS` sit elsewhere in the window.
 - **Postgres.** The stand is sqlite; prod is Postgres. The case removes `unsafe_sqlite` (which
   turns off the journal and gives undefined post-crash state) so that at least the crash
   semantics resemble a journalled database.

--- a/tests/stand/cases/outbox_fetch_failure/README.md
+++ b/tests/stand/cases/outbox_fetch_failure/README.md
@@ -144,10 +144,15 @@ a RECOVERY that is really a clean CONTROL run.
   when a level is filled to `smart_rollup_max_outbox_messages_per_level`). Both levels of this
   window carry exactly 1 message, so that branch never fires — and a level queued by *it*, not
   by an inbox message, has no inbox id protecting it at all.
-- **The `1 + max(id)` cursor off-by-one** at `rollup_message.py:410`: the restart resumes at
-  `1 + last saved id` and then queries `id.gt=` that value, so inbox id `max + 1` is skipped
-  entirely. Visible in the arms' facts (CONTROL's sentinel lands on 38278430, RECOVERY's on
-  38278431) but not asserted — no message of this window happens to sit on the skipped id.
+- **The cursor off-by-one** at `rollup_message.py:487`: the restart resumes at `1 + last saved
+  id` and then queries `id.gt=` that value, so the message at `last saved id + 1` is skipped
+  entirely; `:511` seeds the same cursor from the first message of a fresh window and drops
+  that one. Raw TzKT ids are contiguous and the `type.in=transfer,external` filter only breaks
+  the run at level boundaries, so the skipped position holds a real message in 88% of cursor
+  positions. Visible in the arms' facts (CONTROL's sentinel lands on 38278430, RECOVERY's on
+  38278431) but not asserted, and this case's own fixture rides on it: `CASE_SENTINEL_SEED_ID`
+  is one below the page's first external, which the restart arms therefore drop. Neither
+  affects the verdict — `CASE_EXTERNAL_IDS` sit elsewhere in the window.
 - **Postgres.** The stand is sqlite; prod is Postgres. The case removes `unsafe_sqlite` (which
   turns off the journal and gives undefined post-crash state) so that at least the crash
   semantics resemble a journalled database.

--- a/tests/stand/cases/outbox_fetch_failure/README.md
+++ b/tests/stand/cases/outbox_fetch_failure/README.md
@@ -69,10 +69,19 @@ make test-indexer CASE=outbox_fetch_failure
 
 ## Expected
 
-The four arms and what `run_arms.sh` asserts about each. A failed **precondition** aborts the
+The six arms and what `run_arms.sh` asserts about each. A failed **precondition** aborts the
 run as VOID (exit 2) — a sequence that cannot mean what it is supposed to mean must not be
-reported as RED or GREEN.
+reported as RED or GREEN. An arm whose *behaviour* is wrong aborts as RED (exit 1) instead.
 
+The first two arms are about which levels may be asked for at all; the last four are about what
+survives a fetch that fails.
+
+- **WEDGED** (`PROXY_WEDGED_AT=4285911`, fresh db) — the node stopped applying L1 blocks and
+  still answers RPC, reporting a level below both outbox levels. Neither can be served, so
+  neither may be asked for: exit **0** (the pass finishes instead of dying), zero outbox rows,
+  and inbox rows present — an arm that never reached the drain proves nothing ⇒ VOID.
+- **WEDGE-RECOVERY** (healthy node, same db) — both levels indexed. The debt the wedged arm
+  recorded is what makes this reachable; the cursor is already past those externals.
 - **CONTROL** (`PROXY_FAIL_LEVELS=`, fresh db) — exit 0, `rollup_outbox_message` = exactly the
   2 rows of levels 4285912 and 4286481, `rollup_inbox_message` = the two transfers + the
   level=0 cursor sentinel. Anything else means the window rotted off the rolling node ⇒ VOID.
@@ -144,6 +153,11 @@ a RECOVERY that is really a clean CONTROL run.
   when a level is filled to `smart_rollup_max_outbox_messages_per_level`). Both levels of this
   window carry exactly 1 message, so that branch never fires — and a level queued by *it*, not
   by an inbox message, has no inbox id protecting it at all.
+- **A real wedged node.** `PROXY_WEDGED_AT` encodes what the endpoint means — `head/level` is
+  the last level the node applied, and the level above it has no hash to resolve, verified
+  against a healthy node as an exact boundary (that level 200, the next 500 `kind: temporary`).
+  That a node which *stops* applying reports its frozen level rather than an advancing one
+  follows from the same semantics but was never observed on a broken node.
 - **Postgres.** The stand is sqlite; prod is Postgres. The case removes `unsafe_sqlite` (which
   turns off the journal and gives undefined post-crash state) so that at least the crash
   semantics resemble a journalled database.

--- a/tests/stand/cases/outbox_fetch_failure/README.md
+++ b/tests/stand/cases/outbox_fetch_failure/README.md
@@ -1,0 +1,158 @@
+# Case: outbox-fetch-failure — a transient rollup-node error costs outbox messages for good
+
+`RollupMessageIndex._process` drains the pending outbox levels like this
+(`handlers/rollup_message.py:304-308`):
+
+```python
+while len(self._outbox_level_queue) > 0 and (...):
+    outbox_level = self._outbox_level_queue.pop()     # removed from the set FIRST
+    await self._handle_outbox_level(outbox_level)     # ...then the network call
+```
+
+`_handle_outbox_level` does an unguarded `self._rollup_node.request(...)`
+(`rollup_message.py:359`). Nothing on the path `on_head` → `handle_realtime` → `_process` →
+`_handle_outbox_level` (nor `on_restart` → `synchronize` → `_process` → …) catches transport
+errors, so one 500 from the rollup node aborts the callback — with the level already out of
+the queue and `_create_outbox_batch` never flushed.
+
+The recovery question is decided by the inbox cursor. `_process` bulk-creates the inbox
+messages of the page **before** the drain, and the next start resumes at
+`1 + last saved inbox id` (`_prepare_new_index`, `rollup_message.py:410`). Any outbox level
+enqueued by an external message *below* that id is therefore never queued again — the index
+reports itself caught up while those outbox messages are simply absent.
+
+## The window
+
+One TzKT inbox page (`level.ge=4285890` → ids 38264644..38278225, levels 4285890..4287084) on
+the post-reset Tezos X previewnet rollup `sr1BvTT7…`:
+
+| inbox id | level | kind | effect |
+|---|---|---|---|
+| 38264766 | 4285901 | transfer | saved by `bulk_create` |
+| 38264889 | 4285912 | external | enqueues outbox level 4285912 — **1 message** |
+| 38271382 | 4286481 | external | enqueues outbox level 4286481 — **1 message** |
+| 38271561 | 4286496 | transfer | saved by `bulk_create` — becomes the resume cursor |
+
+Both outbox-carrying levels sit *between* the two transfers, so a crash during the drain
+leaves a cursor above them. Every number above lives in `window.env` (the `CASE_*` variables);
+`run_arms.sh` sources that file and `verify.py` parses it, so this table is the only copy that
+can go stale — check it against `window.env` if you edit either.
+
+The `rollup_node` datasource points at `proxy.py`, a pass-through proxy for the real node that
+answers a chosen outbox level with a chosen status (default 500 — the shape a wedged node has
+in production: it 500s for every level above its `processed_level`). Upstream bodies are
+cached, so the arms differ only by the injected failure. The rollup node is a **rolling** node
+(it serves roughly the last ~250k L1 levels); once this window ages out, re-pick one with
+`proxy.py prewarm` + a scan for non-empty `global/block/<L>/outbox/<L>/messages`.
+
+## Run
+
+```bash
+tests/stand/cases/outbox_fetch_failure/run_arms.sh   # asserts; exit 0 GREEN / 1 RED / 2 VOID
+make inspect-test CASE=outbox_fetch_failure          # same verdict on the state the last arm left
+```
+
+`run_arms.sh` needs no argument and prints every arm's facts as JSON (also collected in
+`$OUT/arms.json`, with the logs and the per-arm env files; `OUT_DIR` moves them).
+`SQLITE_PATH` / `PROXY_PORT` / `PROXY_CACHE_DIR` override `window.env` so a second sequence can
+run beside this one from another worktree — the response cache is only read after the prewarm
+and may be shared. `ARM_TIMEOUT` (default 600s) bounds a single arm, so a fix with an unbounded
+retry loop fails instead of hanging.
+
+Single arms by hand (the proxy must be running; `make test-indexer` wipes the sqlite, which is
+exactly what the restart arms must not do):
+
+```bash
+PROXY_FAIL_LEVELS=4285912 uv run python tests/stand/cases/outbox_fetch_failure/proxy.py &
+make test-indexer CASE=outbox_fetch_failure
+```
+
+## Expected
+
+The four arms and what `run_arms.sh` asserts about each. A failed **precondition** aborts the
+run as VOID (exit 2) — a sequence that cannot mean what it is supposed to mean must not be
+reported as RED or GREEN.
+
+- **CONTROL** (`PROXY_FAIL_LEVELS=`, fresh db) — exit 0, `rollup_outbox_message` = exactly the
+  2 rows of levels 4285912 and 4286481, `rollup_inbox_message` = the two transfers + the
+  level=0 cursor sentinel. Anything else means the window rotted off the rolling node ⇒ VOID.
+- **TREATMENT** (`PROXY_FAIL_LEVELS=4285912`, fresh db) — DipDup aborts with a
+  `ClientResponseError: 500` raised through `_handle_outbox_level` → `_process` → `synchronize`
+  → `on_restart`; DipDup re-raises it and the process exits **1** (an unhandled exception, not
+  a DipDup exit code). Asserted: nonzero exit, **both** inbox transfers committed, **zero**
+  outbox rows, and `rollup_message.py`/`ClientResponseError` in the traceback. If it crashed
+  *before* the inbox `bulk_create`, the db is empty, the restart arms degenerate into a clean
+  CONTROL run that passes with no fix at all ⇒ VOID.
+- **TREATMENT-AGAIN** (fault still armed, same db, no wipe) — the production node stayed broken
+  across many restarts, so a fix whose pending-level state survives one restart but is dropped
+  on the second must not reach RECOVERY intact. Either exit code is legitimate here (a fix
+  retries and crashes again; the unfixed code never asks for the level again), so only the db
+  is asserted: the committed inbox transfers are still there, i.e. nothing wiped them.
+- **RECOVERY** (healthy node, same db, no wipe) — must advance the inbox cursor past
+  TREATMENT's (otherwise the restart did not run the backfill at all ⇒ VOID), and then the
+  verdict is taken on what it leaves.
+
+`verify.py` (the verdict, also reachable as `make inspect-test`) requires, on that final state:
+
+- `rollup_outbox_message` holds exactly 2 rows and its levels are exactly {4285912, 4286481};
+- each row is usable, not just present: `index == 0`, `parameters_hash` set (an unhashed row
+  never matches a withdrawal), `cemented_level > level`;
+- **permanence**, asserted rather than printed: a missing outbox level is only forgivable while
+  the cursor can still reach it — nothing persisted, inbox row or level=0 sentinel, may sit
+  above the id of the external message that enqueues it;
+- the arm actually advanced the backfill: a level=0 sentinel above the window's transfers.
+  ("both transfers saved" cannot say this — TREATMENT wrote those rows and they survive by
+  design, so the check passes even if the restart does nothing.)
+
+RED, the current behaviour, means the restart resumed at inbox id 38271562, never re-queued
+4285912/4286481, and both outbox messages stay missing forever.
+
+### Pre-seeded state
+
+Production always carries the previous page's level=0 cursor sentinel; this window is a single
+page, so TREATMENT crashes before writing one and the restart arms would inherit a database no
+prod restart ever sees. Of the two ways to fix that — span two inbox pages, or seed the row —
+the case seeds it (`CASE_SENTINEL_SEED_ID`, one id below the page's first message), because a
+two-page window would be ~20k inbox messages and would move every id in the table above.
+
+It matters because of `unique_together ('level', 'index')` on `(0, 0)`: `_process` deletes old
+sentinels with `id__lt=cursor` before creating the new one, so a fix that *rewinds* the cursor
+below an existing sentinel leaves it undeleted and raises `IntegrityError` on the create — in
+production, and now here too.
+
+### Harness self-tests
+
+A gate that can only ever say RED is worth nothing, so the harness tests itself:
+
+```bash
+HARNESS_SELFTEST=green tests/stand/cases/outbox_fetch_failure/run_arms.sh   # must exit 0 GREEN
+HARNESS_SELFTEST=void  tests/stand/cases/outbox_fetch_failure/run_arms.sh   # must exit 2 VOID
+```
+
+`green` rewinds the inbox cursor to the sentinel before each restart arm — by hand, what a real
+fix has to achieve — and the sequence must end GREEN. `void` runs TREATMENT against a dead TzKT
+so it dies before the inbox `bulk_create`, and the run must abort as VOID rather than sail on to
+a RECOVERY that is really a clean CONTROL run.
+
+## What this case does NOT cover
+
+- **The realtime drain.** Everything here happens under `on_restart` → `synchronize`;
+  `handle_realtime` is never entered and `_realtime_head_level` stays 0. The realtime path pops
+  the same queue with the same unguarded fetch, but a loss there is not necessarily permanent
+  (the cursor may still be below the external), and this case says nothing about it.
+- **The full-outbox continuation** at `rollup_message.py:405` (`_outbox_level_queue.add(outbox_level + 1)`
+  when a level is filled to `smart_rollup_max_outbox_messages_per_level`). Both levels of this
+  window carry exactly 1 message, so that branch never fires — and a level queued by *it*, not
+  by an inbox message, has no inbox id protecting it at all.
+- **The `1 + max(id)` cursor off-by-one** at `rollup_message.py:410`: the restart resumes at
+  `1 + last saved id` and then queries `id.gt=` that value, so inbox id `max + 1` is skipped
+  entirely. Visible in the arms' facts (CONTROL's sentinel lands on 38278430, RECOVERY's on
+  38278431) but not asserted — no message of this window happens to sit on the skipped id.
+- **Postgres.** The stand is sqlite; prod is Postgres. The case removes `unsafe_sqlite` (which
+  turns off the journal and gives undefined post-crash state) so that at least the crash
+  semantics resemble a journalled database.
+
+A variant worth knowing: with `ROLLUP_SYNC_FIRST_LEVEL=4288010` /
+`ROLLUP_SYNC_LAST_LEVEL=4289200` the page contains **no** transfers, so a crash leaves no inbox
+row at all and the restart replays the whole window — the loss is silent but not permanent.
+Permanence is a property of the cursor, not of the queue.

--- a/tests/stand/cases/outbox_fetch_failure/config.yaml
+++ b/tests/stand/cases/outbox_fetch_failure/config.yaml
@@ -1,0 +1,89 @@
+# Standalone config for the outbox-fetch-failure case. See README.md.
+# sqlite + oneshot (no tezos.head, last_level on every index).
+#
+# The subject is NOT an index: it is the rollup-message backfill that `on_restart` drives
+# (RollupMessageIndex.synchronize -> _process -> _handle_outbox_level). The L1 index below is a
+# tiny no-op window that only gives `dipdup run` something bounded to finish on.
+#
+# `rollup_node` deliberately points at the case's fault-injecting proxy (ROLLUP_NODE_URL in
+# window.env), not at the real node — the CONTROL and TREATMENT arms differ only by the
+# proxy's PROXY_FAIL_LEVELS.
+
+spec_version: 3.0
+package: rollup_bridge_indexer
+
+
+database:
+  kind: sqlite
+  path: ${SQLITE_PATH:-/tmp/bridge_outbox_fetch_failure.sqlite}
+
+
+datasources:
+  tzkt:
+    kind: tezos.tzkt
+    url: ${TZKT_URL}
+
+  metadata:
+    kind: tzip_metadata
+    network: ${NETWORK}
+    url: ${METADATA_URL}
+
+  tezos_node:
+    kind: http
+    url: ${TEZOS_NODE_URL}
+
+  # Same http settings as the prod base config (dipdup.yaml) — retry_count is load-bearing:
+  # the injected failure must survive the retries and reach the caller (2 retries, then
+  # `_retry_request` re-raises the ClientResponseError).
+  #
+  # `request_timeout: 4` is far below the proxy's 30s upstream fetch, so a cache MISS could
+  # surface as a TimeoutError that looks exactly like the injected fault. run_arms.sh keeps
+  # that out of the run by asserting the prewarmed cache covers every level of the page
+  # before any arm starts.
+  rollup_node:
+    kind: http
+    url: ${ROLLUP_NODE_URL}
+    http:
+      retry_count: 2
+      retry_sleep: 1.0
+      retry_multiplier: 1.0
+      connection_timeout: 1
+      request_timeout: 4
+
+
+contracts:
+  tezos_smart_rollup:
+    kind: tezos
+    address: ${SMART_ROLLUP_ADDRESS}
+    typename: rollup
+
+
+indexes:
+  tezos_deposit_operations:
+    kind: tezos.operations
+    first_level: ${L1_FIRST_LEVEL}
+    last_level: ${L1_LAST_LEVEL}
+    datasources:
+      - tzkt
+    types:
+      - transaction
+    contracts:
+      - tezos_smart_rollup
+    handlers:
+      - callback: tezos.on_rollup_call
+        pattern:
+          - type: transaction
+            destination: tezos_smart_rollup
+            entrypoint: default
+
+
+# No `unsafe_sqlite` here (prod runs Postgres with a journal): it sets journal_mode=OFF and
+# synchronous=OFF, i.e. undefined database state after a crash — and this case's whole subject
+# is what survives a crash mid-run.
+advanced:
+  reindex:
+    config_modified: ignore
+    schema_modified: ignore
+    migration: ignore
+    rollback: ignore
+    manual: wipe

--- a/tests/stand/cases/outbox_fetch_failure/proxy.py
+++ b/tests/stand/cases/outbox_fetch_failure/proxy.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Fault-injecting pass-through proxy for the `rollup_node` datasource.
+
+Sits between the indexer and the real rollup node so a single outbox-message fetch can be
+made to fail deterministically, with everything else served byte-identically to the clean
+run. Two arms of the same case differ only by `PROXY_FAIL_LEVELS`.
+
+Modes
+  serve                  run the proxy (default)
+  prewarm LO HI [WANT]   fill the response cache for `global/block/<L>/outbox/<L>/messages`,
+                         L in [LO, HI), concurrently — so a `serve` run never waits on
+                         upstream and both arms see identical upstream bodies. Exits
+                         non-zero unless the cache ends up holding every level of the range
+                         (and exactly WANT entries, when given): a cold entry would be
+                         fetched under the datasource's `request_timeout`, which is far
+                         below this proxy's 30s upstream timeout, and the resulting
+                         TimeoutError is indistinguishable from the injected fault.
+  check PORT TOKEN LEVELS STATUS
+                         poll `/__armed` until the proxy answers and assert it is the one
+                         this arm meant to start (same token) with the intended fault spec.
+                         Exits non-zero otherwise — an arm run against the previous arm's
+                         proxy proves nothing.
+
+Env
+  PROXY_PORT        listen port (default 8642)
+  PROXY_UPSTREAM    real rollup node (default https://previewnet-smart.tzkt.io)
+  PROXY_CACHE_DIR   response cache dir (default /tmp/bridge_outbox_fetch_failure_cache)
+  PROXY_FAIL_LEVELS comma-separated outbox levels to fail; empty = pass-through (CONTROL)
+  PROXY_FAIL_STATUS HTTP status to answer with (default 500 — the production shape: a wedged
+                    rollup node 500s for every level above its processed_level)
+  PROXY_TOKEN       identity string echoed by `/__armed` (default: a random one)
+  PROXY_LOG         request log path (default /tmp/bridge_outbox_fetch_failure_proxy.log)
+
+The failure is applied BEFORE the cache, so every retry of the same request fails too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+import aiohttp
+from aiohttp import web
+
+PORT = int(os.environ.get('PROXY_PORT', '8642'))
+UPSTREAM = os.environ.get('PROXY_UPSTREAM', 'https://previewnet-smart.tzkt.io').rstrip('/')
+CACHE_DIR = Path(os.environ.get('PROXY_CACHE_DIR', '/tmp/bridge_outbox_fetch_failure_cache'))
+FAIL_STATUS = int(os.environ.get('PROXY_FAIL_STATUS', '500'))
+TOKEN = os.environ.get('PROXY_TOKEN') or uuid.uuid4().hex
+LOG_PATH = Path(os.environ.get('PROXY_LOG', '/tmp/bridge_outbox_fetch_failure_proxy.log'))
+
+FAIL_LEVELS = {int(x) for x in os.environ.get('PROXY_FAIL_LEVELS', '').replace(',', ' ').split()}
+
+OUTBOX_RE = re.compile(r'^global/block/(\d+)/outbox/(\d+)/messages$')
+
+
+def _cache_file(path: str, query: str) -> Path:
+    key = hashlib.sha256(f'{path}?{query}'.encode()).hexdigest()[:32]
+    return CACHE_DIR / f'{key}.bin'
+
+
+def _log(line: str) -> None:
+    with LOG_PATH.open('a') as fh:
+        fh.write(line + '\n')
+
+
+async def _fetch(session: aiohttp.ClientSession, path: str, query: str) -> tuple[int, bytes]:
+    url = f'{UPSTREAM}/{path}' + (f'?{query}' if query else '')
+    async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        return resp.status, await resp.read()
+
+
+async def armed(request: web.Request) -> web.Response:
+    """Identity + fault spec of THIS process. `check` asserts an arm talks to the right proxy."""
+    return web.json_response(
+        {
+            'token': TOKEN,
+            'pid': os.getpid(),
+            'port': PORT,
+            'upstream': UPSTREAM,
+            'cache_dir': str(CACHE_DIR),
+            'fail_levels': sorted(FAIL_LEVELS),
+            'fail_status': FAIL_STATUS,
+            'log': str(LOG_PATH),
+        }
+    )
+
+
+async def handle(request: web.Request) -> web.Response:
+    path = request.match_info.get('tail', '').lstrip('/')
+    query = request.rel_url.query_string
+
+    match = OUTBOX_RE.match(path)
+    if match and int(match.group(2)) in FAIL_LEVELS:
+        _log(f'FAIL {FAIL_STATUS} {path}')
+        return web.Response(status=FAIL_STATUS, body=b'injected upstream failure', content_type='text/plain')
+
+    cache_file = _cache_file(path, query)
+    if cache_file.exists():
+        _log(f'HIT  {path}')
+        return web.Response(status=200, body=cache_file.read_bytes(), content_type='application/json')
+
+    status, body = await _fetch(request.app['session'], path, query)
+    _log(f'MISS {status} {path}')
+    if status == 200:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        cache_file.write_bytes(body)
+    return web.Response(status=status, body=body, content_type='application/json')
+
+
+async def _on_startup(app: web.Application) -> None:
+    app['session'] = aiohttp.ClientSession()
+
+
+async def _on_cleanup(app: web.Application) -> None:
+    await app['session'].close()
+
+
+def serve() -> int:
+    LOG_PATH.write_text('')
+    app = web.Application()
+    app.router.add_route('GET', '/__armed', armed)
+    app.router.add_route('*', '/{tail:.*}', handle)
+    app.on_startup.append(_on_startup)
+    app.on_cleanup.append(_on_cleanup)
+    spec = sorted(FAIL_LEVELS) or 'none (pass-through)'
+    print(f'proxy :{PORT} -> {UPSTREAM}  fail={spec}/{FAIL_STATUS}  token={TOKEN}  pid={os.getpid()}', flush=True)
+    try:
+        web.run_app(app, host='127.0.0.1', port=PORT, print=None)
+    except OSError as exc:  # a port still held by the previous arm must not look like a clean start
+        print(f'proxy: FAILED to bind 127.0.0.1:{PORT}: {exc}', flush=True)
+        return 1
+    return 0
+
+
+def check(port: int, token: str, levels: str, status: int, tries: int = 40) -> int:
+    """Poll `/__armed` and assert the answering proxy is this arm's, with this arm's fault."""
+    want_levels = sorted({int(x) for x in levels.replace(',', ' ').split()})
+    body: dict = {}
+    for _ in range(tries):
+        try:
+            with urllib.request.urlopen(f'http://127.0.0.1:{port}/__armed', timeout=2) as resp:
+                body = json.loads(resp.read())
+            break
+        except (OSError, urllib.error.URLError, ValueError):
+            time.sleep(0.5)
+    else:
+        print(f'proxy check: nothing answered http://127.0.0.1:{port}/__armed', flush=True)
+        return 1
+
+    print(f'proxy armed: {json.dumps(body, sort_keys=True)}', flush=True)
+    problems = []
+    if body.get('token') != token:
+        problems.append(f'token {body.get("token")} != {token} (a stale proxy is holding the port)')
+    if body.get('fail_levels') != want_levels:
+        problems.append(f'fail_levels {body.get("fail_levels")} != {want_levels}')
+    if body.get('fail_status') != status:
+        problems.append(f'fail_status {body.get("fail_status")} != {status}')
+    for problem in problems:
+        print(f'proxy check: {problem}', flush=True)
+    return 1 if problems else 0
+
+
+async def _prewarm(lo: int, hi: int) -> int:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    sem = asyncio.Semaphore(20)
+    filled = 0
+    async with aiohttp.ClientSession() as session:
+
+        async def one(level: int) -> None:
+            nonlocal filled
+            path = f'global/block/{level}/outbox/{level}/messages'
+            cache_file = _cache_file(path, '')
+            if cache_file.exists():
+                return
+            async with sem:
+                for _ in range(3):
+                    try:
+                        status, body = await _fetch(session, path, '')
+                    except Exception:  # retry any transport error
+                        await asyncio.sleep(1)
+                        continue
+                    if status == 200:
+                        cache_file.write_bytes(body)
+                        filled += 1
+                    return
+
+        await asyncio.gather(*(one(level) for level in range(lo, hi)))
+
+    present = sum(1 for level in range(lo, hi) if _cache_file(f'global/block/{level}/outbox/{level}/messages', '').exists())
+    print(f'prewarm: {present}/{hi - lo} levels cached ({filled} new) in {CACHE_DIR}', flush=True)
+    return present
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if argv and argv[0] == 'prewarm':
+        lo, hi = int(argv[1]), int(argv[2])
+        want = int(argv[3]) if len(argv) > 3 else hi - lo
+        present = asyncio.run(_prewarm(lo, hi))
+        if present != hi - lo or present != want:
+            print(f'prewarm: FAILED — {present} cached entries, expected {want}', flush=True)
+            return 1
+        return 0
+    if argv and argv[0] == 'check':
+        return check(int(argv[1]), argv[2], argv[3], int(argv[4]))
+    return serve()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/stand/cases/outbox_fetch_failure/proxy.py
+++ b/tests/stand/cases/outbox_fetch_failure/proxy.py
@@ -3,7 +3,7 @@
 
 Sits between the indexer and the real rollup node so a single outbox-message fetch can be
 made to fail deterministically, with everything else served byte-identically to the clean
-run. Two arms of the same case differ only by `PROXY_FAIL_LEVELS`.
+run. Arms of the same case differ only by `PROXY_FAIL_LEVELS` and `PROXY_WEDGED_AT`.
 
 Modes
   serve                  run the proxy (default)
@@ -26,6 +26,9 @@ Env
   PROXY_UPSTREAM    real rollup node (default https://previewnet-smart.tzkt.io)
   PROXY_CACHE_DIR   response cache dir (default /tmp/bridge_outbox_fetch_failure_cache)
   PROXY_FAIL_LEVELS comma-separated outbox levels to fail; empty = pass-through (CONTROL)
+  PROXY_WEDGED_AT   pretend the node stopped applying L1 blocks here: `global/block/head/level`
+                    reports this level and every outbox above it answers PROXY_FAIL_STATUS in
+                    the upstream's own error shape; 0 (default) passes the real level through
   PROXY_FAIL_STATUS HTTP status to answer with (default 500 — the production shape: a wedged
                     rollup node 500s for every level above its processed_level)
   PROXY_TOKEN       identity string echoed by `/__armed` (default: a random one)
@@ -106,9 +109,14 @@ async def handle(request: web.Request) -> web.Response:
     path = request.match_info.get('tail', '').lstrip('/')
     query = request.rel_url.query_string
 
-    if WEDGED_AT and path == HEAD_LEVEL_PATH:
-        _log(f'WEDGE head/level -> {WEDGED_AT}')
-        return web.Response(status=200, body=str(WEDGED_AT).encode(), content_type='application/json')
+    if path == HEAD_LEVEL_PATH:
+        if WEDGED_AT:
+            _log(f'WEDGE head/level -> {WEDGED_AT}')
+            return web.Response(status=200, body=str(WEDGED_AT).encode(), content_type='application/json')
+        # Never cached: a frozen head level is the fault this case injects deliberately.
+        status, body = await _fetch(request.app['session'], path, query)
+        _log(f'HEAD {status} {path}')
+        return web.Response(status=status, body=body, content_type='application/json')
 
     match = OUTBOX_RE.match(path)
     if match and WEDGED_AT and int(match.group(2)) > WEDGED_AT:

--- a/tests/stand/cases/outbox_fetch_failure/proxy.py
+++ b/tests/stand/cases/outbox_fetch_failure/proxy.py
@@ -60,7 +60,13 @@ LOG_PATH = Path(os.environ.get('PROXY_LOG', '/tmp/bridge_outbox_fetch_failure_pr
 
 FAIL_LEVELS = {int(x) for x in os.environ.get('PROXY_FAIL_LEVELS', '').replace(',', ' ').split()}
 
+# A wedged node: it stopped applying L1 blocks but still answers RPC. `head/level` reports the
+# last level it applied, and every level above that has no hash it can resolve — the shape of
+# the 2026-08-20 fault. 0 means the node is healthy and this is passed straight through.
+WEDGED_AT = int(os.environ.get('PROXY_WEDGED_AT', '0'))
+
 OUTBOX_RE = re.compile(r'^global/block/(\d+)/outbox/(\d+)/messages$')
+HEAD_LEVEL_PATH = 'global/block/head/level'
 
 
 def _cache_file(path: str, query: str) -> Path:
@@ -90,6 +96,7 @@ async def armed(request: web.Request) -> web.Response:
             'cache_dir': str(CACHE_DIR),
             'fail_levels': sorted(FAIL_LEVELS),
             'fail_status': FAIL_STATUS,
+            'wedged_at': WEDGED_AT,
             'log': str(LOG_PATH),
         }
     )
@@ -99,7 +106,19 @@ async def handle(request: web.Request) -> web.Response:
     path = request.match_info.get('tail', '').lstrip('/')
     query = request.rel_url.query_string
 
+    if WEDGED_AT and path == HEAD_LEVEL_PATH:
+        _log(f'WEDGE head/level -> {WEDGED_AT}')
+        return web.Response(status=200, body=str(WEDGED_AT).encode(), content_type='application/json')
+
     match = OUTBOX_RE.match(path)
+    if match and WEDGED_AT and int(match.group(2)) > WEDGED_AT:
+        _log(f'WEDGE {FAIL_STATUS} {path}')
+        return web.Response(
+            status=FAIL_STATUS,
+            body=b'{"kind":"temporary","id":"failure","msg":"Cannot retrieve hash of level"}',
+            content_type='application/json',
+        )
+
     if match and int(match.group(2)) in FAIL_LEVELS:
         _log(f'FAIL {FAIL_STATUS} {path}')
         return web.Response(status=FAIL_STATUS, body=b'injected upstream failure', content_type='text/plain')

--- a/tests/stand/cases/outbox_fetch_failure/run_arms.sh
+++ b/tests/stand/cases/outbox_fetch_failure/run_arms.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Four-arm protocol for the outbox-fetch-failure case. See README.md.
+#
+#   CONTROL         proxy passes everything through       -> both outbox messages indexed
+#   TREATMENT       proxy fails one outbox level          -> indexer aborts, nothing saved
+#   TREATMENT-AGAIN restart, SAME db, fault STILL armed   -> prod stayed broken across restarts
+#   RECOVERY        proxy healthy again, SAME db, no wipe -> does the restart get them back?
+#
+# The script ASSERTS: every arm's facts go to $OUT/arms.json, an arm that cannot mean what it
+# is supposed to mean aborts the run, and the last thing it does is run the verifier and exit
+# with its status.
+#
+#   exit 0  GREEN — the outbox messages survived the failure
+#   exit 1  RED   — they are gone (the current, unfixed behaviour)
+#   exit 2  VOID  — the run proves nothing (harness/proxy/arm-precondition failure)
+#
+# Usage: tests/stand/cases/outbox_fetch_failure/run_arms.sh
+#
+# Env: SQLITE_PATH / PROXY_PORT / PROXY_CACHE_DIR / OUT_DIR override window.env, so a second
+# sequence can run beside this one from another worktree (the response cache is only read
+# after the prewarm and may be shared). ARM_TIMEOUT bounds a single dipdup arm.
+#
+# HARNESS_SELFTEST proves the gate can still move in both directions — see README.md:
+#   green  rewind the inbox cursor before each restart arm (what a real fix must achieve)
+#          => the sequence must end GREEN, exit 0
+#   void   run TREATMENT against a dead TzKT so it dies before the inbox bulk_create
+#          => the sequence must abort VOID, exit 2 (never GREEN off an empty database)
+set -u
+
+cd "$(dirname "$0")/../../../.." || exit 1
+CASE=outbox_fetch_failure
+CASE_DIR=tests/stand/cases/$CASE
+
+# Shell env wins over window.env; window.env holds the defaults and every window constant.
+_env_sqlite=${SQLITE_PATH:-}
+_env_port=${PROXY_PORT:-}
+_env_cache=${PROXY_CACHE_DIR:-}
+set -a
+# shellcheck source=window.env
+. "$CASE_DIR/window.env"
+set +a
+SQLITE_PATH=${_env_sqlite:-$SQLITE_PATH}
+PROXY_PORT=${_env_port:-$CASE_PROXY_PORT}
+PROXY_CACHE_DIR=${_env_cache:-$CASE_PROXY_CACHE_DIR}
+FAIL_STATUS=$CASE_FAIL_STATUS
+FAIL_LEVEL=$CASE_FAIL_LEVEL
+OUT=${OUT_DIR:-/tmp/outbox_fetch_failure}
+ARM_TIMEOUT=${ARM_TIMEOUT:-600}
+SELFTEST=${HARNESS_SELFTEST:-}
+ARGS="-e tests/stand/tezosx.env -e ${CASE_DIR}/window.env -c ${CASE_DIR}/config.yaml"
+VERIFY="python3 -m tests.stand.cases.${CASE}.verify"
+
+# A fix must re-reach the external message whose outbox level was lost; the self-test does it
+# by hand, rewinding the cursor to the sentinel so the restart replays the page.
+REWIND_SQL='DELETE FROM rollup_inbox_message WHERE id > ?'
+SEED_SENTINEL_SQL=$(
+	cat <<-'SQL'
+		INSERT OR REPLACE INTO rollup_inbox_message
+		    (id, level, "index", type, message, parameters_hash, created_at, updated_at)
+		VALUES (?, 0, 0, 'external', '{}', NULL, datetime('now'), datetime('now'))
+	SQL
+)
+
+export PROXY_PORT PROXY_CACHE_DIR SQLITE_PATH PYTHONPATH=.
+mkdir -p "$OUT"
+: >"$OUT/arms.jsonl"
+
+write_arms_json() { # $1 = verdict state, $2 = note
+	python3 - "$OUT/arms.jsonl" "$OUT/arms.json" "$1" "$2" <<-'PY'
+		import json
+		import os
+		import sys
+
+		jsonl, out, state, note = sys.argv[1:5]
+		arms = [json.loads(line) for line in open(jsonl) if line.strip()]
+		window = {k: v for k, v in os.environ.items() if k.startswith(('CASE_', 'ROLLUP_SYNC_'))}
+		report = {'case': 'outbox_fetch_failure', 'window': window, 'arms': arms, 'verdict': {'state': state, 'note': note}}
+		with open(out, 'w') as fh:
+		    json.dump(report, fh, indent=2)
+		    fh.write('\n')
+		print(f'{out}: {state} ({note})')
+	PY
+}
+
+port_pid() { ss -lptn "sport = :$PROXY_PORT" 2>/dev/null | grep -o 'pid=[0-9]*' | head -1 | cut -d= -f2; }
+
+proxy_stop() { # returns 1 if the port is still held — never pretend a stale proxy is gone
+	local pid
+	for _ in $(seq 1 20); do
+		pid=$(port_pid)
+		[ -z "$pid" ] && return 0
+		kill "$pid" 2>/dev/null
+		sleep 0.5
+	done
+	pid=$(port_pid)
+	[ -n "$pid" ] && kill -9 "$pid" 2>/dev/null
+	sleep 1
+	[ -z "$(port_pid)" ]
+}
+
+die() { # a run that cannot mean what it is supposed to mean is VOID, not RED
+	echo
+	echo "VOID: $*" >&2
+	write_arms_json VOID "$*"
+	proxy_stop
+	exit 2
+}
+
+trap 'proxy_stop >/dev/null 2>&1' EXIT
+
+proxy_start() { # $1 = arm, $2 = PROXY_FAIL_LEVELS value
+	proxy_stop || die "port $PROXY_PORT is still held by another process"
+	PROXY_TOKEN="$1-$$-$(date +%s%N)"
+	PROXY_FAIL_LEVELS="$2" PROXY_FAIL_STATUS="$FAIL_STATUS" PROXY_TOKEN="$PROXY_TOKEN" PROXY_LOG="$OUT/$1.proxy.log" \
+		setsid uv run python "$CASE_DIR/proxy.py" >"$OUT/$1.proxy.out" 2>&1 &
+	# Identity, not liveness: the arm must talk to the proxy IT started, with ITS fault spec.
+	uv run python "$CASE_DIR/proxy.py" check "$PROXY_PORT" "$PROXY_TOKEN" "$2" "$FAIL_STATUS" || {
+		cat "$OUT/$1.proxy.out"
+		die "arm $1 is not talking to the proxy it started (see $OUT/$1.proxy.out)"
+	}
+}
+
+sql() { # $1 = statement with ? placeholders, $2.. = integer params (sqlite3(1) is not installed)
+	python3 - "$SQLITE_PATH" "$@" <<-'PY'
+		import sqlite3
+		import sys
+
+		conn = sqlite3.connect(sys.argv[1])
+		cur = conn.execute(sys.argv[2], tuple(int(a) for a in sys.argv[3:]))
+		conn.commit()
+		print(f'  sql: {cur.rowcount} row(s)')
+	PY
+}
+
+fact() { printf '%s' "$1" | python3 -c 'import json,sys;print(json.load(sys.stdin)[sys.argv[1]])' "$2"; }
+
+run_arm() { # $1 = arm, $2 = PROXY_FAIL_LEVELS value, $3.. = extra env lines for this arm only
+	local arm=$1 spec=$2 rc
+	shift 2
+	{
+		echo "SQLITE_PATH=$SQLITE_PATH"
+		echo "ROLLUP_NODE_URL=http://127.0.0.1:$PROXY_PORT/"
+		for line in "$@"; do echo "$line"; done
+	} >"$OUT/$arm.env"
+
+	echo
+	echo "=== $arm (fail=${spec:-none}/$FAIL_STATUS) ==="
+	proxy_start "$arm" "$spec"
+	timeout --kill-after=30 "$ARM_TIMEOUT" uv run dipdup $ARGS -e "$OUT/$arm.env" run >"$OUT/$arm.log" 2>&1
+	rc=$?
+	if [ "$rc" = 124 ]; then
+		echo "arm $arm hit ARM_TIMEOUT=${ARM_TIMEOUT}s and was killed"
+	fi
+	ARM_FACTS=$($VERIFY --facts "$arm" "$rc" "$spec" "$FAIL_STATUS" "$SQLITE_PATH") ||
+		die "could not collect facts for arm $arm"
+	printf '%s\n' "$ARM_FACTS" >>"$OUT/arms.jsonl"
+	echo "$ARM_FACTS"
+}
+
+# --- Prewarm: every level the drain can ask for must already be cached. A cold entry is
+# fetched under the datasource's request_timeout (4s) through the proxy's 30s upstream path,
+# and the resulting TimeoutError is indistinguishable from the injected fault. ---
+uv run python "$CASE_DIR/proxy.py" prewarm "$CASE_PREWARM_FIRST_LEVEL" "$CASE_PREWARM_LAST_LEVEL" "$CASE_PREWARM_ENTRIES" ||
+	die "prewarm did not leave $CASE_PREWARM_ENTRIES cached entries in $PROXY_CACHE_DIR"
+
+# --- CONTROL: healthy node, fresh db. Anything but a complete index means the window rotted. ---
+rm -f "$SQLITE_PATH"
+run_arm control ''
+[ "$(fact "$ARM_FACTS" exit_code)" = 0 ] || die "CONTROL must exit 0 (got $(fact "$ARM_FACTS" exit_code)); see $OUT/control.log"
+[ "$(fact "$ARM_FACTS" outbox_levels_missing)" = 0 ] || die "CONTROL did not index $CASE_OUTBOX_LEVELS — the window no longer holds them"
+[ "$(fact "$ARM_FACTS" outbox_rows)" = "$CASE_OUTBOX_ROWS" ] || die "CONTROL left $(fact "$ARM_FACTS" outbox_rows) outbox rows, expected $CASE_OUTBOX_ROWS"
+
+# --- TREATMENT: the fault. It must crash IN the outbox drain: after the inbox bulk_create
+# (rows committed) and before any outbox row is flushed. A crash before the bulk_create leaves
+# an empty db, RECOVERY degenerates into a clean CONTROL run and the case would go GREEN with
+# no fix at all — that state is VOID, not RED. ---
+rm -f "$SQLITE_PATH"
+if [ "$SELFTEST" = void ]; then
+	run_arm treatment "$FAIL_LEVEL" 'TZKT_URL=http://127.0.0.1:1'
+else
+	run_arm treatment "$FAIL_LEVEL"
+fi
+[ "$(fact "$ARM_FACTS" exit_code)" != 0 ] || die "TREATMENT exited 0 — the injected $FAIL_STATUS never reached the caller"
+[ "$(fact "$ARM_FACTS" transfers_present)" = 2 ] ||
+	die "TREATMENT crashed before the inbox bulk_create ($(fact "$ARM_FACTS" transfers_present)/2 transfers committed) — nothing is stranded, the run proves nothing"
+[ "$(fact "$ARM_FACTS" outbox_rows)" = 0 ] ||
+	die "TREATMENT left $(fact "$ARM_FACTS" outbox_rows) outbox rows — the drain was not interrupted where the case needs it"
+grep -qE 'rollup_message\.py|ClientResponseError' "$OUT/treatment.log" ||
+	die "TREATMENT's traceback does not mention rollup_message.py — it died somewhere else"
+TREATMENT_MAX_ID=$(fact "$ARM_FACTS" max_inbox_id)
+
+# Prod always carries the previous page's level=0 cursor sentinel; this window is one page, so
+# TREATMENT leaves none. Seed it so both restart arms inherit a prod-shaped database.
+sql "$SEED_SENTINEL_SQL" "$CASE_SENTINEL_SEED_ID" || die "could not seed the level=0 cursor sentinel"
+echo "seeded level=0 cursor sentinel at id $CASE_SENTINEL_SEED_ID"
+
+# --- TREATMENT-AGAIN: the node is still broken, as it was in production across many restarts.
+# A fix that remembers the pending level over one restart but forgets it on the next must not
+# reach RECOVERY with its state intact. Either exit code is legitimate here (a fix retries and
+# crashes again; the unfixed code never asks again), so only the database is asserted. ---
+if [ "$SELFTEST" = green ]; then
+	sql "$REWIND_SQL" "$CASE_SENTINEL_SEED_ID"
+fi
+run_arm treatment_again "$FAIL_LEVEL"
+[ "$(fact "$ARM_FACTS" transfers_present)" = 2 ] || die "TREATMENT-AGAIN lost the committed inbox transfers — the db was wiped between arms"
+
+# --- RECOVERY: healthy node, same db, no wipe. The verdict is taken on what it leaves. ---
+if [ "$SELFTEST" = green ]; then
+	sql "$REWIND_SQL" "$CASE_SENTINEL_SEED_ID"
+fi
+run_arm recovery ''
+[ "$(fact "$ARM_FACTS" max_inbox_id)" -gt "$TREATMENT_MAX_ID" ] ||
+	die "RECOVERY did not advance the inbox cursor past TREATMENT's ($TREATMENT_MAX_ID) — the restart did not run the backfill"
+
+proxy_stop || die "port $PROXY_PORT is still held after the last arm"
+
+echo
+echo "=== verdict (state left by RECOVERY) ==="
+$VERIFY "$SQLITE_PATH"
+rc=$?
+write_arms_json "$([ "$rc" = 0 ] && echo GREEN || echo RED)" "verify.py exit $rc"
+echo "logs, per-arm env files and arms.json in $OUT"
+exit $rc

--- a/tests/stand/cases/outbox_fetch_failure/run_arms.sh
+++ b/tests/stand/cases/outbox_fetch_failure/run_arms.sh
@@ -106,12 +106,21 @@ die() { # a run that cannot mean what it is supposed to mean is VOID, not RED
 	exit 2
 }
 
+red() { # the code did the wrong thing, which is a different verdict from a broken instrument
+	echo
+	echo "RED: $*" >&2
+	write_arms_json RED "$*"
+	proxy_stop
+	exit 1
+}
+
 trap 'proxy_stop >/dev/null 2>&1' EXIT
 
 proxy_start() { # $1 = arm, $2 = PROXY_FAIL_LEVELS value
 	proxy_stop || die "port $PROXY_PORT is still held by another process"
 	PROXY_TOKEN="$1-$$-$(date +%s%N)"
 	PROXY_FAIL_LEVELS="$2" PROXY_FAIL_STATUS="$FAIL_STATUS" PROXY_TOKEN="$PROXY_TOKEN" PROXY_LOG="$OUT/$1.proxy.log" \
+		PROXY_WEDGED_AT="${WEDGE:-0}" \
 		setsid uv run python "$CASE_DIR/proxy.py" >"$OUT/$1.proxy.out" 2>&1 &
 	# Identity, not liveness: the arm must talk to the proxy IT started, with ITS fault spec.
 	uv run python "$CASE_DIR/proxy.py" check "$PROXY_PORT" "$PROXY_TOKEN" "$2" "$FAIL_STATUS" || {
@@ -162,6 +171,24 @@ run_arm() { # $1 = arm, $2 = PROXY_FAIL_LEVELS value, $3.. = extra env lines for
 # and the resulting TimeoutError is indistinguishable from the injected fault. ---
 uv run python "$CASE_DIR/proxy.py" prewarm "$CASE_PREWARM_FIRST_LEVEL" "$CASE_PREWARM_LAST_LEVEL" "$CASE_PREWARM_ENTRIES" ||
 	die "prewarm did not leave $CASE_PREWARM_ENTRIES cached entries in $PROXY_CACHE_DIR"
+
+# --- WEDGED: the node stopped applying L1 blocks and still answers RPC. Its reported level is
+# below both outbox levels, so neither can be served — and neither may be asked for. A drain
+# that asks anyway takes the process down, which is the state this arm exists to rule out. ---
+rm -f "$SQLITE_PATH"
+WEDGE="$CASE_WEDGE_LEVEL" run_arm wedged ''
+[ "$(fact "$ARM_FACTS" exit_code)" = 0 ] ||
+	red "WEDGED must finish cleanly, not die on a level the node cannot serve (exit $(fact "$ARM_FACTS" exit_code)); see $OUT/wedged.log"
+[ "$(fact "$ARM_FACTS" outbox_rows)" = 0 ] ||
+	red "WEDGED indexed $(fact "$ARM_FACTS" outbox_rows) outbox row(s) from a node that reports level $CASE_WEDGE_LEVEL"
+[ "$(fact "$ARM_FACTS" inbox_rows)" -gt 0 ] ||
+	die "WEDGED indexed no inbox rows — the arm never reached the drain and proves nothing"
+
+# --- WEDGE-RECOVERY: same database, the node has caught up. The debt the wedged arm recorded
+# is what makes this possible; without it the cursor is already past those externals. ---
+run_arm wedge_recovery ''
+[ "$(fact "$ARM_FACTS" outbox_levels_missing)" = 0 ] ||
+	red "WEDGE-RECOVERY left $(fact "$ARM_FACTS" outbox_levels_missing) outbox level(s) unindexed; see $OUT/wedge_recovery.log"
 
 # --- CONTROL: healthy node, fresh db. Anything but a complete index means the window rotted. ---
 rm -f "$SQLITE_PATH"

--- a/tests/stand/cases/outbox_fetch_failure/verify.py
+++ b/tests/stand/cases/outbox_fetch_failure/verify.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""outbox-fetch-failure verdict: a transient rollup-node failure must not cost outbox messages.
+
+Run after the four-arm protocol in README.md (`run_arms.sh`, which calls this file itself and
+propagates its exit code). The verdict is taken on the state left by the LAST arm — the
+restart against a fully healthy rollup node:
+
+  GREEN  both outbox messages of the window are in `rollup_outbox_message`, complete and
+         usable (index/parameters_hash/cemented_level), i.e. the indexer either absorbed the
+         failure or re-fetched the level after recovery.
+  RED    the levels the failed drain popped are gone for good: the inbox cursor has moved
+         past the external messages that enqueue them, so no later run ever asks for them.
+
+The CONTROL arm alone also satisfies the check — that is the point of the differential: the
+same verifier separates the arms.
+
+Modes
+  verify.py [SQLITE]                         the verdict above (`make inspect-test`)
+  verify.py --facts ARM EXIT LEVELS STATUS   one JSON line of per-arm facts for run_arms.sh
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+from tests.stand import verify_lib as lib
+
+CASE_DIR = Path(__file__).resolve().parent
+
+
+def load_window() -> dict[str, str]:
+    """Parse `window.env` — the single home of this case's constants (see the file's header)."""
+    values: dict[str, str] = {}
+    for line in (CASE_DIR / 'window.env').read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        key, _, value = line.partition('=')
+        values[key.strip()] = value.strip()
+    return values
+
+
+W = load_window()
+
+# Levels the window's external inbox messages enqueue that actually carry outbox messages.
+EXPECTED_OUTBOX_LEVELS = tuple(int(x) for x in W['CASE_OUTBOX_LEVELS'].split(','))
+EXPECTED_OUTBOX_ROWS = int(W['CASE_OUTBOX_ROWS'])
+
+# The two transfers that straddle them (see window.env). Their ids are what strands the levels:
+# the highest one becomes the resume cursor, and it is above the externals of both levels.
+TRANSFER_IDS = tuple(int(x) for x in W['CASE_TRANSFER_IDS'].split(','))
+STRANDED_EXTERNAL_IDS = {int(level): int(id_) for level, id_ in (p.split(':') for p in W['CASE_EXTERNAL_IDS'].split(','))}
+
+
+def _db_path(argv: list[str]) -> str:
+    return argv[0] if argv else os.environ.get('SQLITE_PATH', '/tmp/bridge_outbox_fetch_failure.sqlite')
+
+
+def facts(arm: str, exit_code: int, fail_levels: str, fail_status: int, path: str) -> dict:
+    """Machine-readable state of one arm: what it exited with, and what it left in the db."""
+    out: dict = {
+        'arm': arm,
+        'exit_code': exit_code,
+        'fail_levels': sorted({int(x) for x in fail_levels.replace(',', ' ').split()}),
+        'fail_status': fail_status,
+        'db_present': Path(path).exists(),
+        'inbox_rows': -1,
+        'outbox_rows': -1,
+        'max_inbox_id': 0,
+        'transfer_ids_present': [],
+        'transfers_present': 0,
+        'sentinel_ids': [],
+        'outbox_levels': [],
+        'outbox_level_present': {},
+        'outbox_levels_missing': len(EXPECTED_OUTBOX_LEVELS),
+    }
+    if not out['db_present']:
+        return out
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    out['inbox_rows'] = lib.count(cur, 'rollup_inbox_message')
+    out['outbox_rows'] = lib.count(cur, 'rollup_outbox_message')
+    inbox = [r['id'] for r in lib.rows(cur, 'SELECT id FROM rollup_inbox_message')] if out['inbox_rows'] >= 0 else []
+    out['max_inbox_id'] = max(inbox, default=0)
+    out['transfer_ids_present'] = [i for i in TRANSFER_IDS if i in set(inbox)]
+    out['transfers_present'] = len(out['transfer_ids_present'])
+    if out['inbox_rows'] >= 0:
+        out['sentinel_ids'] = [r['id'] for r in lib.rows(cur, 'SELECT id FROM rollup_inbox_message WHERE level = 0 ORDER BY id')]
+    if out['outbox_rows'] >= 0:
+        out['outbox_levels'] = [r['level'] for r in lib.rows(cur, 'SELECT level FROM rollup_outbox_message ORDER BY level')]
+    out['outbox_level_present'] = {str(level): level in set(out['outbox_levels']) for level in EXPECTED_OUTBOX_LEVELS}
+    out['outbox_levels_missing'] = sum(1 for present in out['outbox_level_present'].values() if not present)
+    conn.close()
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == '--facts':
+        arm, exit_code, fail_levels, fail_status = argv[1], int(argv[2]), argv[3], int(argv[4])
+        print(json.dumps(facts(arm, exit_code, fail_levels, fail_status, _db_path(argv[5:]))))
+        return 0
+
+    conn = lib.open_db(_db_path(argv))
+    cur = conn.cursor()
+
+    lib.counts(cur, 'rollup_inbox_message', 'rollup_outbox_message')
+
+    lib.section('rollup_outbox_message')
+    outbox = lib.rows(cur, 'SELECT level, "index" AS idx, parameters_hash, cemented_level FROM rollup_outbox_message ORDER BY level')
+    for r in outbox:
+        print(f'  level={r["level"]}  index={r["idx"]}  parameters_hash={r["parameters_hash"]}  cemented_level={r["cemented_level"]}')
+
+    inbox = lib.dump(cur, 'rollup_inbox_message', 'id, level, type', order_by='id')
+
+    levels = {r['level'] for r in outbox}
+    cursor_id = max((r['id'] for r in inbox), default=0)
+    sentinels = [r['id'] for r in inbox if r['level'] == 0]
+
+    lib.section('Resume cursor vs the levels the drain popped')
+    print(f'  highest saved inbox id (next run resumes at id+1): {cursor_id}')
+    print(f'  level=0 cursor sentinels: {sentinels or "none"}')
+    for level, external_id in STRANDED_EXTERNAL_IDS.items():
+        stranded = cursor_id > external_id and level not in levels
+        print(f'  outbox level {level}: enqueued by inbox id {external_id} -> {"STRANDED" if stranded else "reachable/indexed"}')
+
+    v = lib.Verdict()
+    v.check(len(outbox) == EXPECTED_OUTBOX_ROWS, f'rollup_outbox_message holds exactly {EXPECTED_OUTBOX_ROWS} rows (got {len(outbox)})')
+    v.check(levels == set(EXPECTED_OUTBOX_LEVELS), f'outbox levels are exactly {sorted(EXPECTED_OUTBOX_LEVELS)} (got {sorted(levels)})')
+    for r in outbox:
+        # A row that exists but cannot be matched or executed is not a recovered message.
+        v.check(r['idx'] == 0, f'outbox level {r["level"]}: index == 0')
+        v.check(r['parameters_hash'] is not None, f'outbox level {r["level"]}: parameters_hash is set (matchable)')
+        v.check(r['cemented_level'] > r['level'], f'outbox level {r["level"]}: cemented_level {r["cemented_level"]} > level')
+
+    # The permanence of the loss, asserted rather than printed: an outbox level may only be
+    # missing while the inbox cursor still sits at or below the external message that queues
+    # it. Nothing persisted — an inbox row OR a level=0 sentinel — may be above it.
+    for level, external_id in STRANDED_EXTERNAL_IDS.items():
+        v.check(
+            level in levels or cursor_id <= external_id,
+            f'outbox level {level} indexed, or still reachable (no inbox row/sentinel above id {external_id}; highest is {cursor_id})',
+        )
+
+    # The last arm must have actually advanced the backfill: `_process` writes a level=0
+    # cursor sentinel at the id it stopped on, above the window's transfers. TREATMENT dies
+    # before that, so this separates "the restart ran" from "the restart did nothing" — which
+    # the inbox transfers cannot, they were committed by TREATMENT and survive by design.
+    v.check(
+        any(sentinel > max(TRANSFER_IDS) for sentinel in sentinels),
+        f'the arm advanced the backfill past the window (level=0 sentinel above id {max(TRANSFER_IDS)}; got {sentinels or "none"})',
+    )
+    conn.close()
+    return v.report()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/stand/cases/outbox_fetch_failure/window.env
+++ b/tests/stand/cases/outbox_fetch_failure/window.env
@@ -1,0 +1,72 @@
+# Block window for the outbox-fetch-failure case. See README.md.
+#
+# This file is the ONLY home of the window constants: `run_arms.sh` sources it and
+# `verify.py` parses it (`load_window()`), so the harness, the verdict and the docs cannot
+# drift apart. The CASE_* variables below are read by the harness only — DipDup ignores them.
+#
+# Rollup: the post-reset Tezos X previewnet rollup sr1BvTT7… (tezosx.env still names the
+# pre-reset sr1TCYof…, which the live rollup node no longer serves), overridden here because
+# `dipdup -e` applies the case env file last.
+SMART_ROLLUP_ADDRESS=sr1BvTT7tVNneG2TeP18sixq57TxsZELebLu
+
+# The `rollup_node` datasource is aimed at the case's fault-injecting proxy (proxy.py).
+# Keep the port in sync with CASE_PROXY_PORT below; run_arms.sh rewrites both together when
+# PROXY_PORT is overridden, this value only serves a hand-run `make test-indexer`.
+ROLLUP_NODE_URL=http://127.0.0.1:8642/
+
+# Inbox-backfill window (on_restart -> RollupMessageIndex.synchronize).
+#
+# TzKT returns exactly one 10000-message page for `level.ge=4285890`: ids 38264644..38278225,
+# levels 4285890..4287084. Inside that single page:
+#   id 38264766  level 4285901  TRANSFER to sr1BvTT7…   <- committed by bulk_create
+#   id 38264889  level 4285912  external -> enqueues outbox level 4285912 (1 message)
+#   id 38271382  level 4286481  external -> enqueues outbox level 4286481 (1 message)
+#   id 38271561  level 4286496  TRANSFER to sr1BvTT7…   <- committed by bulk_create
+# The two transfers straddle the two outbox-carrying levels, so after the inbox bulk_create
+# the highest saved inbox id (38271561) is ABOVE the externals that enqueued them — which is
+# what makes a crash during the outbox drain unrecoverable on restart.
+#
+# ROLLUP_SYNC_LAST_LEVEL must sit ABOVE the last level of that page (4287084). If it fell
+# inside the page, `_process` would flip the index to `realtime` during the inbox loop and
+# then SKIP the outbox drain entirely (`status == syncing or min(queue) <= _realtime_head_level`,
+# and _realtime_head_level is 0 on a oneshot run) — the code under test would never run.
+ROLLUP_SYNC_FIRST_LEVEL=4285890
+ROLLUP_SYNC_LAST_LEVEL=4287100
+
+# L1 index window: a deliberately empty 5-block window. The case is about the rollup backfill,
+# not about an index; this only bounds `dipdup run` so it exits on its own.
+L1_FIRST_LEVEL=4285890
+L1_LAST_LEVEL=4285895
+
+SQLITE_PATH=/tmp/bridge_outbox_fetch_failure.sqlite
+
+# --- Harness constants (run_arms.sh + verify.py; not used by DipDup) ---
+
+# Proxy identity/placement. Override PROXY_PORT / PROXY_CACHE_DIR / SQLITE_PATH in the
+# environment to run a second sequence next to this one (a worktree); the response cache can
+# be shared, it is only ever read after the prewarm.
+CASE_PROXY_PORT=8642
+CASE_PROXY_CACHE_DIR=/tmp/bridge_outbox_fetch_failure_cache
+
+# Prewarm covers exactly the page's levels, so no arm ever fetches upstream while running:
+# a cold entry would take the proxy's 30s upstream path and trip the datasource's
+# request_timeout (4s, see config.yaml), which is indistinguishable from the injected fault.
+CASE_PREWARM_FIRST_LEVEL=4285890
+CASE_PREWARM_LAST_LEVEL=4287085
+CASE_PREWARM_ENTRIES=1195
+
+# The injected fault: the first of the two outbox-carrying levels, answered with the shape a
+# wedged rollup node has in production (500 for every level above its processed_level).
+CASE_FAIL_LEVEL=4285912
+CASE_FAIL_STATUS=500
+
+# What a correct run must end with, and the inbox ids that decide reachability.
+CASE_OUTBOX_LEVELS=4285912,4286481
+CASE_OUTBOX_ROWS=2
+CASE_TRANSFER_IDS=38264766,38271561
+CASE_EXTERNAL_IDS=4285912:38264889,4286481:38271382
+
+# Prod always carries the previous page's `level=0` cursor sentinel; this window is one page,
+# so TREATMENT crashes before writing one. Seeded between the arms at one id below the page's
+# first inbox message (38264644) to give the restart arms a prod-shaped database.
+CASE_SENTINEL_SEED_ID=38264643

--- a/tests/stand/cases/outbox_fetch_failure/window.env
+++ b/tests/stand/cases/outbox_fetch_failure/window.env
@@ -70,3 +70,7 @@ CASE_EXTERNAL_IDS=4285912:38264889,4286481:38271382
 # so TREATMENT crashes before writing one. Seeded between the arms at one id below the page's
 # first inbox message (38264644) to give the restart arms a prod-shaped database.
 CASE_SENTINEL_SEED_ID=38264643
+
+# The level a wedged node reports as its last applied one. Below both CASE_OUTBOX_LEVELS, so
+# neither is servable; above ROLLUP_SYNC_FIRST_LEVEL, so the inbox walk still runs.
+CASE_WEDGE_LEVEL=4285911

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,7 +40,9 @@ async def init_empty_schema(db_url: str = DB_URL) -> None:
     A fresh in-memory sqlite is empty by construction; a server-backed database outlives
     the test, so drop and recreate the schema to get the same starting point.
     """
-    await Tortoise.init(db_url=db_url, modules={'models': ['rollup_bridge_indexer.models']})
+    # `dipdup.models` too: DipDup's own tables (dipdup_meta among them) are part of every real
+    # database, and the rollup-message index keeps its pending outbox levels there.
+    await Tortoise.init(db_url=db_url, modules={'models': ['rollup_bridge_indexer.models', 'dipdup.models']})
     if not db_url.startswith('sqlite'):
         await Tortoise.get_connection('default').execute_script('DROP SCHEMA public CASCADE; CREATE SCHEMA public;')
     await Tortoise.generate_schemas()

--- a/tests/unit/rollup/test_inbox_cursor.py
+++ b/tests/unit/rollup/test_inbox_cursor.py
@@ -1,0 +1,181 @@
+"""Contract: the inbox backfill asks for every message in the window, exactly once.
+
+`RollupMessageIndex` walks TzKT's inbox with a single cursor and the filter
+`v1/smart_rollups/inbox?id.gt=<cursor>`. Strictly greater — so the cursor means *the last id
+already consumed*, and that is what the in-run advance stores. The two places that derive it
+from persisted state have to mean the same thing, or the message at the boundary is requested
+by nobody: not by the run that stopped short of it, not by the run that resumes above it.
+
+Nothing reports such a hole. The index is `realtime`, `dipdup_head` is at the chain head, and
+the missing message is simply a deposit that never matches, or an `external` whose outbox level
+is never queued.
+
+The two boundaries, one test each:
+
+  * a restart, which resumes from the last saved row;
+  * a fresh database, which starts from the first message of the window.
+
+Offline: the fake TzKT here answers *from a universe* by applying the filter in the URL, so a
+message that is never asked for is a row that is never written. That is the whole instrument —
+the assertions are about the rows in the database, not about the URLs, because a recorded URL
+cannot tell you whether anything was lost.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from rollup_bridge_indexer.handlers.rollup_message import RollupMessageIndex
+from rollup_bridge_indexer.models import RollupInboxMessage
+from rollup_bridge_indexer.models import RollupInboxMessageType
+
+pytestmark = pytest.mark.anyio
+
+ROLLUP = 'sr1BvTT7tVNneG2TeP18sixq57TxsZELebLu'
+ORIGINATION_LEVEL = 1
+BLOCK_TIMESTAMP = '2026-01-01T00:00:00Z'
+
+# Ids are contiguous in the real stream: TzKT numbers every inbox message, and the
+# `type.in=transfer,external` filter only breaks the run at level boundaries. A universe
+# without gaps is therefore the honest shape, and it is the one where a skip is visible.
+UNIVERSE_IDS = range(100, 106)
+
+
+def _message(message_id: int) -> dict[str, Any]:
+    """A transfer to the rollup — indexed unconditionally, so presence is decided by the fetch."""
+    return {
+        'id': message_id,
+        'level': message_id - 90,
+        'index': 0,
+        'type': RollupInboxMessageType.transfer.value,
+        'target': {'address': ROLLUP},
+        'parameter': {'entrypoint': 'default', 'value': {'int': str(message_id)}},
+    }
+
+
+UNIVERSE = [_message(i) for i in UNIVERSE_IDS]
+
+
+class UniverseTzkt:
+    """Serves the inbox from a fixed universe by applying the filter it is handed.
+
+    The production fakes elsewhere in this suite hand back a canned page and ignore the URL;
+    that is what makes them blind to which messages were requested. This one is the opposite:
+    it holds every message that exists and lets the query decide.
+    """
+
+    def __init__(self, universe: list[dict[str, Any]], head_level: int = 10_000) -> None:
+        self.universe = universe
+        self.head_level = head_level
+        self.urls: list[str] = []
+
+    async def get_head_block(self) -> Any:
+        return SimpleNamespace(level=self.head_level)
+
+    @staticmethod
+    def _param(url: str, name: str) -> int | None:
+        for part in url.split('?', 1)[-1].split('&'):
+            key, _, value = part.partition('=')
+            if key == name:
+                return int(value)
+        return None
+
+    async def request(self, method: Any = None, url: Any = None, **kwargs: Any) -> Any:
+        if url.startswith('v1/smart_rollups/inbox'):
+            self.urls.append(url)
+            id_gt = self._param(url, 'id.gt')
+            level_ge = self._param(url, 'level.ge')
+            limit = self._param(url, 'limit') or len(self.universe)
+            page = [m for m in self.universe if (id_gt is None or m['id'] > id_gt) and (level_ge is None or m['level'] >= level_ge)]
+            return page[:limit]
+        if url.startswith('v1/smart_rollups/'):
+            return {'firstActivity': ORIGINATION_LEVEL}
+        if url.startswith('v1/blocks/'):
+            return BLOCK_TIMESTAMP
+        raise AssertionError(f'unexpected TzKT request: {url}')
+
+
+class SilentRollupNode:
+    """No outbox messages anywhere: these tests are about the inbox side only."""
+
+    async def request(self, method: Any = None, url: Any = None, **kwargs: Any) -> Any:
+        return []
+
+
+def _index(tzkt: Any) -> RollupMessageIndex:
+    bridge: Any = SimpleNamespace(smart_rollup_address=ROLLUP)
+    protocol: Any = SimpleNamespace(
+        smart_rollup_commitment_period=60,
+        smart_rollup_challenge_window=40,
+        smart_rollup_max_outbox_messages_per_level=100,
+    )
+    # Stand-ins for the container's settings objects; nothing on the inbox path reads more
+    # than the fields above, and no outbox message ever reaches the ticket service.
+    rollup_node: Any = SilentRollupNode()
+    ticket_service: Any = None
+    return RollupMessageIndex(
+        tzkt=tzkt,
+        rollup_node=rollup_node,
+        bridge=bridge,
+        ticket_service=ticket_service,
+        protocol=protocol,
+        logger=logging.getLogger('test.rollup_message'),
+    )
+
+
+async def _indexed_ids() -> list[int]:
+    return [m.id for m in await RollupInboxMessage.all().order_by('id')]
+
+
+async def _seed(message_ids: list[int]) -> None:
+    """Rows a previous run committed, written directly — the seam under test is the next run."""
+    await RollupInboxMessage.bulk_create(
+        [
+            RollupInboxMessage(
+                id=i,
+                level=_message(i)['level'],
+                index=0,
+                type=RollupInboxMessageType.transfer,
+                message=_message(i)['parameter'],
+                parameters_hash=f'{i:032d}',
+            )
+            for i in message_ids
+        ]
+    )
+    # The seam only exists if the rows are really there; a seed that silently wrote nothing
+    # would send this test down the fresh-database path and pass for the wrong reason.
+    assert await _indexed_ids() == message_ids
+
+
+async def test_a_restart_asks_for_the_message_after_the_last_saved_one(db: Any) -> None:
+    """The resume seam: the first unindexed message must not fall between the two runs.
+
+    A previous run committed ids 100-102 and stopped — a page boundary, a crash, a redeploy.
+    Whatever resumes has to pick up at 103.
+    """
+    await _seed([100, 101, 102])
+
+    tzkt = UniverseTzkt(UNIVERSE)
+    index = _index(tzkt)
+    await index._prepare_new_index()
+    await index._process()
+
+    assert await _indexed_ids() == list(UNIVERSE_IDS), 'the restart lost the message it resumed on top of'
+
+
+async def test_a_fresh_database_indexes_the_first_message_of_the_window(db: Any) -> None:
+    """The other seam: the window's first message is found by a lookup, then used as a cursor.
+
+    A cursor is the last id consumed, and that message has not been consumed by anyone yet.
+    """
+    tzkt = UniverseTzkt(UNIVERSE)
+    index = _index(tzkt)
+    index._sync_first_level = UNIVERSE[0]['level']
+    await index._prepare_new_index()
+    await index._process()
+
+    assert await _indexed_ids() == list(UNIVERSE_IDS), 'the first message of the window was never requested'

--- a/tests/unit/rollup/test_outbox_level_durability.py
+++ b/tests/unit/rollup/test_outbox_level_durability.py
@@ -16,8 +16,8 @@ outbox_fetch_failure/`) cannot reach:
 
   * the continuation level of a full outbox, which has no inbox message behind it at all —
     both when the chain has not reached it yet and when its own fetch fails;
-  * the realtime deferral and the order the drain serves the queue in, which the oneshot
-    stand never enters (`_realtime_head_level` stays 0 there).
+  * the deferral of a level the rollup node has not applied yet, and the order the drain
+    serves the queue in.
 
 Offline: no TzKT, no rollup node — both datasources are fakes, and the database is the
 in-memory sqlite of the `db` fixture.
@@ -94,8 +94,6 @@ class FakeTzkt:
         self.head_level = head_level
 
     async def get_head_block(self) -> Any:
-        # `_prepare_new_index` seeds `_realtime_head_level` from this, so a restored level is
-        # not asked for before the chain can answer for it.
         return SimpleNamespace(level=self.head_level)
 
     async def request(self, method: Any = None, url: Any = None, **kwargs: Any) -> Any:
@@ -109,15 +107,25 @@ class FakeTzkt:
 
 
 class FakeRollupNode:
-    """`global/block/<level>/outbox/<level>/messages`, per level, and a record of who asked."""
+    """`global/block/<level>/outbox/<level>/messages`, per level, and a record of who asked.
 
-    def __init__(self, responses: dict[int, Any]) -> None:
+    `processed_level` is what the node says it has applied (`global/block/head/level`). A node
+    that stopped applying blocks keeps answering RPC and reports its frozen level; every level
+    above it has no hash it can resolve, so it answers 500.
+    """
+
+    def __init__(self, responses: dict[int, Any], processed_level: int = 10**9) -> None:
         self.responses = responses
+        self.processed_level = processed_level
         self.requested: list[int] = []
 
     async def request(self, method: Any = None, url: Any = None, **kwargs: Any) -> Any:
+        if url == 'global/block/head/level':
+            return self.processed_level
         level = int(url.split('/')[2])
         self.requested.append(level)
+        if level > self.processed_level:
+            raise _server_error()
         response = self.responses[level]
         if isinstance(response, Exception):
             raise response
@@ -155,42 +163,41 @@ async def _pending_levels() -> list[int]:
 
 
 async def test_full_outbox_continuation_level_is_deferred_and_stored(db: Any) -> None:
-    """F6 + F7: `outbox_level + 1` above the realtime head is stored, not fetched.
+    """F6 + F7: `outbox_level + 1` above what the node has applied is stored, not fetched.
 
     A level queued by a full outbox has no inbox message behind it, so the resume cursor
     cannot describe it — the stored queue is its only record. And it must not be fetched
-    before the chain reaches it: the node has no such block yet.
+    before the node can answer for it.
     """
     node = FakeRollupNode(
         {
             # A full outbox at 100 -> the drain queues 101 for the rest of the messages.
             100: [UNHASHABLE_MESSAGE] * MAX_OUTBOX_MESSAGES_PER_LEVEL,
             101: [],
-        }
+        },
+        processed_level=100,
     )
     index = _index(FakeTzkt(), node)
     index._status = IndexStatus.realtime
-    index._realtime_head_level = 100
     index._outbox_level_queue = {100}
 
     await index._drain_outbox_levels()
 
-    assert node.requested == [100], 'level 101 is above the realtime head and must not be fetched yet'
+    assert node.requested == [100], 'level 101 is above what the node has applied and must not be fetched yet'
     assert await _pending_levels() == [101], 'the continuation level must outlive the process that queued it'
 
-    # A restart takes it over — and still defers it until the head arrives.
+    # A restart takes it over — and still defers it until the node catches up.
     restarted = _index(FakeTzkt(), node)
     await restarted._load_pending_outbox_levels()
     assert restarted._outbox_level_queue == {101}
 
     restarted._status = IndexStatus.realtime
-    restarted._realtime_head_level = 100
     await restarted._drain_outbox_levels()
-    assert node.requested == [100], 'a restored level above the head must stay deferred'
+    assert node.requested == [100], 'a restored level the node cannot answer for must stay deferred'
 
-    restarted._realtime_head_level = 101
+    node.processed_level = 101
     await restarted._drain_outbox_levels()
-    assert node.requested == [100, 101], 'once the head reaches it, the restored level is fetched'
+    assert node.requested == [100, 101], 'once the node applies it, the restored level is fetched'
     assert await _pending_levels() == []
 
 
@@ -218,7 +225,6 @@ async def test_pending_levels_survive_a_failed_drain(db: Any) -> None:
     index._status = IndexStatus.syncing
     # What `_prepare_new_index` would have seeded on the way into `syncing`; without it the
     # drain would refuse every level as unreached and nothing would be fetched at all.
-    index._realtime_head_level = 12
 
     with pytest.raises(aiohttp.ClientResponseError):
         await index._process()
@@ -274,7 +280,6 @@ async def test_full_outbox_continuation_level_survives_its_failed_fetch(db: Any)
     node = FakeRollupNode({100: full_outbox, 101: _server_error()})
     index = _index(FakeTzkt([page], head_level=head), node)
     index._status = IndexStatus.syncing
-    index._realtime_head_level = head
 
     with pytest.raises(aiohttp.ClientResponseError):
         await index._process()
@@ -314,22 +319,40 @@ async def test_drain_serves_the_lowest_level_and_stops_at_the_head(db: Any) -> N
     # hands back the *higher* one first, so the wrong implementation is observably wrong
     # here instead of getting the right answer by luck.
     head = 207
-    node = FakeRollupNode({207: [_outbox_message(207, 0)], 208: [_outbox_message(208, 0)]})
+    node = FakeRollupNode({207: [_outbox_message(207, 0)], 208: [_outbox_message(208, 0)]}, processed_level=head)
     index = _index(FakeTzkt(head_level=head), node)
     index._status = IndexStatus.realtime
-    index._realtime_head_level = head
     index._outbox_level_queue = {207, 208}
 
     await index._drain_outbox_levels()
 
-    assert node.requested == [207], 'level 208 is above the realtime head and must not be asked for'
+    assert node.requested == [207], 'level 208 is above what the node has applied and must not be asked for'
     assert await _outbox_rows() == [(207, 0)], 'only the reached level produced rows'
     assert await _pending_levels() == [208], 'the unreached level stays owed'
 
-    # Once the head reaches it, the same queue drains the rest.
-    index._realtime_head_level = 208
+    # Once the node applies it, the same queue drains the rest.
+    node.processed_level = 208
     await index._drain_outbox_levels()
 
     assert node.requested == [207, 208]
     assert await _outbox_rows() == [(207, 0), (208, 0)]
     assert await _pending_levels() == []
+
+
+async def test_a_wedged_node_is_not_asked_for_levels_it_cannot_answer(db: Any) -> None:
+    """The 2026-08-20 fault: a node stops applying L1 blocks and still answers RPC.
+
+    Its `head/level` freezes and every level above that answers 500. The L1 chain, meanwhile,
+    keeps producing — so a ceiling taken from the L1 head says "go ahead" for levels the node
+    demonstrably cannot serve, and the drain dies on the first one.
+    """
+    node = FakeRollupNode({300: [_outbox_message(300, 0)], 301: [_outbox_message(301, 0)]}, processed_level=300)
+    index = _index(FakeTzkt(head_level=999), node)
+    index._status = IndexStatus.realtime
+    index._outbox_level_queue = {300, 301}
+
+    await index._drain_outbox_levels()
+
+    assert node.requested == [300], 'only the level the node has applied was asked for'
+    assert await _outbox_rows() == [(300, 0)], 'the served level produced rows'
+    assert await _pending_levels() == [301], 'the level the node cannot answer for stays owed'

--- a/tests/unit/rollup/test_outbox_level_durability.py
+++ b/tests/unit/rollup/test_outbox_level_durability.py
@@ -3,7 +3,7 @@
 `RollupMessageIndex` learns which outbox levels to fetch from the inbox page it is walking
 (`_handle_external_inbox_message`) and from a full outbox asking for its continuation
 (`_handle_outbox_level`, `outbox_level + 1`). Both used to live only in the in-memory
-`_outbox_level_queue`, while the resume cursor — `1 + max(RollupInboxMessage.id)` — was
+`_outbox_level_queue`, while the resume cursor, derived from the last saved inbox row, was
 written *before* the drain. A drain that died halfway therefore resumed above the external
 messages it had not served yet, and those outbox messages were gone for good.
 
@@ -199,7 +199,7 @@ async def test_pending_levels_survive_a_failed_drain(db: Any) -> None:
 
     The page here is the shape that made the production loss permanent: two external
     messages followed by a transfer, so the committed transfer's id is above both externals
-    and `1 + max(id)` can never reach them again.
+    and the resume cursor can never reach them again.
     """
     page = [
         {'id': 100, 'level': 10, 'index': 0, 'type': 'external'},
@@ -232,7 +232,9 @@ async def test_pending_levels_survive_a_failed_drain(db: Any) -> None:
     # Restart on the same database: the cursor cannot reach the externals, the queue can.
     restarted = _index(FakeTzkt([[]], head_level=12), FakeRollupNode({10: [], 11: []}))
     await restarted._prepare_new_index()
-    assert restarted._inbox_id_cursor == 103
+    # At or above the last external, so `id.gt=` can never return either of them again. The
+    # exact resume arithmetic is not this test's business — being out of reach is.
+    assert restarted._inbox_id_cursor >= 101
     assert restarted._outbox_level_queue == {10, 11}
 
     await restarted._process()
@@ -256,7 +258,7 @@ async def test_full_outbox_continuation_level_survives_its_failed_fetch(db: Any)
     page = [
         # The external message that puts level 100 in the queue...
         {'id': 100, 'level': 100, 'index': 0, 'type': 'external'},
-        # ...followed by a transfer, so the committed cursor (`1 + max(id)`) is above it.
+        # ...followed by a transfer, so the committed cursor is above it.
         {
             'id': 101,
             'level': 100,
@@ -290,7 +292,7 @@ async def test_full_outbox_continuation_level_survives_its_failed_fetch(db: Any)
     restarted_node = FakeRollupNode({100: full_outbox, 101: [_outbox_message(101, 0)]})
     restarted = _index(FakeTzkt([[]], head_level=head), restarted_node)
     await restarted._prepare_new_index()
-    assert restarted._inbox_id_cursor == 102, 'the cursor is past both inbox messages of the failed page'
+    assert restarted._inbox_id_cursor >= 100, 'the cursor is past the external message of the failed page'
     assert restarted._outbox_level_queue == {100}, 'the stored queue is what the cursor cannot describe'
 
     await restarted._process()

--- a/tests/unit/rollup/test_outbox_level_durability.py
+++ b/tests/unit/rollup/test_outbox_level_durability.py
@@ -1,0 +1,333 @@
+"""Contract: a pending outbox level survives the process that queued it.
+
+`RollupMessageIndex` learns which outbox levels to fetch from the inbox page it is walking
+(`_handle_external_inbox_message`) and from a full outbox asking for its continuation
+(`_handle_outbox_level`, `outbox_level + 1`). Both used to live only in the in-memory
+`_outbox_level_queue`, while the resume cursor — `1 + max(RollupInboxMessage.id)` — was
+written *before* the drain. A drain that died halfway therefore resumed above the external
+messages it had not served yet, and those outbox messages were gone for good.
+
+The fix stores the queue in DipDup's own `dipdup_meta` key-value table (no package model, no
+schema hash change, no reindex) and drops a level from it only once the messages it produced
+are committed.
+
+These tests cover the paths the block-bounded stand case (`tests/stand/cases/
+outbox_fetch_failure/`) cannot reach:
+
+  * the continuation level of a full outbox, which has no inbox message behind it at all —
+    both when the chain has not reached it yet and when its own fetch fails;
+  * the realtime deferral and the order the drain serves the queue in, which the oneshot
+    stand never enters (`_realtime_head_level` stays 0 there).
+
+Offline: no TzKT, no rollup node — both datasources are fakes, and the database is the
+in-memory sqlite of the `db` fixture.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import aiohttp
+import pytest
+from dipdup.models import IndexStatus
+from dipdup.models import Meta
+from pytezos import MichelsonType
+from pytezos import michelson_to_micheline
+
+from rollup_bridge_indexer.handlers.rollup_message import RollupMessageIndex
+from rollup_bridge_indexer.handlers.ticket import FAST_WITHDRAW_MICHELSON_OUTBOX_MESSAGE_INTERFACE
+from rollup_bridge_indexer.models import RollupInboxMessage
+from rollup_bridge_indexer.models import RollupOutboxMessage
+
+pytestmark = pytest.mark.anyio
+
+ROLLUP = 'sr1BvTT7tVNneG2TeP18sixq57TxsZELebLu'
+ORIGINATION_LEVEL = 1
+BLOCK_TIMESTAMP = '2026-01-01T00:00:00Z'
+
+# Small enough that a two-message outbox counts as full and asks for its continuation.
+MAX_OUTBOX_MESSAGES_PER_LEVEL = 2
+
+# An outbox message the hasher cannot read: it is skipped with a warning, which keeps these
+# tests about the queue rather than about ticket hashing.
+UNHASHABLE_MESSAGE: dict[str, Any] = {'outbox_level': 0, 'message_index': 0, 'message': {}}
+
+_FAST_WITHDRAW_TYPE = MichelsonType.match(michelson_to_micheline(FAST_WITHDRAW_MICHELSON_OUTBOX_MESSAGE_INTERFACE))
+TICKETER = 'KT1MJxf4KVN3sosR99VRG7WBbWTJtAyWUJt9'
+RECEIVER = 'tz1burnburnburnburnburnburnburjAYjjX'
+
+
+def _outbox_message(level: int, index: int) -> dict[str, Any]:
+    """A fast-withdrawal outbox message the hasher *can* read, so it becomes a row.
+
+    The fast-withdrawal shape is the one whose hash needs no ticket lookup, which keeps
+    `ticket_service` out of these tests while still exercising the real insert path.
+    """
+    parameters = _FAST_WITHDRAW_TYPE.from_python_object(
+        {
+            'withdrawal_id': level * 10 + index,
+            'ticket': {'address': TICKETER, 'content': {'nat': 0, 'bytes': None}, 'amount': 1},
+            'timestamp': 0,
+            'base_withdrawer': RECEIVER,
+            'payload': b'',
+            'l2_caller': b'',
+        }
+    ).to_micheline_value()
+    return {
+        'outbox_level': level,
+        'message_index': index,
+        'message': {'transactions': [{'parameters': parameters, 'destination': TICKETER, 'entrypoint': 'default'}]},
+    }
+
+
+async def _outbox_rows() -> list[tuple[int, int]]:
+    return [(row.level, row.index) for row in await RollupOutboxMessage.all().order_by('level', 'index')]
+
+
+class FakeTzkt:
+    """Answers only the three URLs `RollupMessageIndex` asks TzKT for, plus the head block."""
+
+    def __init__(self, inbox_pages: list[list[dict[str, Any]]] | None = None, head_level: int = 0) -> None:
+        self.inbox_pages = list(inbox_pages or [])
+        self.head_level = head_level
+
+    async def get_head_block(self) -> Any:
+        # `_prepare_new_index` seeds `_realtime_head_level` from this, so a restored level is
+        # not asked for before the chain can answer for it.
+        return SimpleNamespace(level=self.head_level)
+
+    async def request(self, method: Any = None, url: Any = None, **kwargs: Any) -> Any:
+        if url.startswith('v1/smart_rollups/inbox'):
+            return self.inbox_pages.pop(0) if self.inbox_pages else []
+        if url.startswith('v1/smart_rollups/'):
+            return {'firstActivity': ORIGINATION_LEVEL}
+        if url.startswith('v1/blocks/'):
+            return BLOCK_TIMESTAMP
+        raise AssertionError(f'unexpected TzKT request: {url}')
+
+
+class FakeRollupNode:
+    """`global/block/<level>/outbox/<level>/messages`, per level, and a record of who asked."""
+
+    def __init__(self, responses: dict[int, Any]) -> None:
+        self.responses = responses
+        self.requested: list[int] = []
+
+    async def request(self, method: Any = None, url: Any = None, **kwargs: Any) -> Any:
+        level = int(url.split('/')[2])
+        self.requested.append(level)
+        response = self.responses[level]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _server_error() -> aiohttp.ClientResponseError:
+    """The shape a wedged rollup node has: 500 for every level above the one it processed."""
+    return aiohttp.ClientResponseError(request_info=None, history=(), status=500, message='Internal Server Error')  # type: ignore[arg-type]
+
+
+def _index(tzkt: Any, rollup_node: Any) -> RollupMessageIndex:
+    # Stand-ins for the container's settings objects; only the fields below are read on
+    # these paths, and `ticket_service` is never reached (every message here is unhashable).
+    bridge: Any = SimpleNamespace(smart_rollup_address=ROLLUP)
+    protocol: Any = SimpleNamespace(
+        smart_rollup_commitment_period=60,
+        smart_rollup_challenge_window=40,
+        smart_rollup_max_outbox_messages_per_level=MAX_OUTBOX_MESSAGES_PER_LEVEL,
+    )
+    ticket_service: Any = None
+    return RollupMessageIndex(
+        tzkt=tzkt,
+        rollup_node=rollup_node,
+        bridge=bridge,
+        ticket_service=ticket_service,
+        protocol=protocol,
+        logger=logging.getLogger('test.rollup_message'),
+    )
+
+
+async def _pending_levels() -> list[int]:
+    meta = await Meta.get_or_none(key=RollupMessageIndex.pending_outbox_levels_key)
+    return list(meta.value) if meta and meta.value else []
+
+
+async def test_full_outbox_continuation_level_is_deferred_and_stored(db: Any) -> None:
+    """F6 + F7: `outbox_level + 1` above the realtime head is stored, not fetched.
+
+    A level queued by a full outbox has no inbox message behind it, so the resume cursor
+    cannot describe it — the stored queue is its only record. And it must not be fetched
+    before the chain reaches it: the node has no such block yet.
+    """
+    node = FakeRollupNode(
+        {
+            # A full outbox at 100 -> the drain queues 101 for the rest of the messages.
+            100: [UNHASHABLE_MESSAGE] * MAX_OUTBOX_MESSAGES_PER_LEVEL,
+            101: [],
+        }
+    )
+    index = _index(FakeTzkt(), node)
+    index._status = IndexStatus.realtime
+    index._realtime_head_level = 100
+    index._outbox_level_queue = {100}
+
+    await index._drain_outbox_levels()
+
+    assert node.requested == [100], 'level 101 is above the realtime head and must not be fetched yet'
+    assert await _pending_levels() == [101], 'the continuation level must outlive the process that queued it'
+
+    # A restart takes it over — and still defers it until the head arrives.
+    restarted = _index(FakeTzkt(), node)
+    await restarted._load_pending_outbox_levels()
+    assert restarted._outbox_level_queue == {101}
+
+    restarted._status = IndexStatus.realtime
+    restarted._realtime_head_level = 100
+    await restarted._drain_outbox_levels()
+    assert node.requested == [100], 'a restored level above the head must stay deferred'
+
+    restarted._realtime_head_level = 101
+    await restarted._drain_outbox_levels()
+    assert node.requested == [100, 101], 'once the head reaches it, the restored level is fetched'
+    assert await _pending_levels() == []
+
+
+async def test_pending_levels_survive_a_failed_drain(db: Any) -> None:
+    """F5: the queue is stored before the inbox rows that move the cursor past its externals.
+
+    The page here is the shape that made the production loss permanent: two external
+    messages followed by a transfer, so the committed transfer's id is above both externals
+    and `1 + max(id)` can never reach them again.
+    """
+    page = [
+        {'id': 100, 'level': 10, 'index': 0, 'type': 'external'},
+        {'id': 101, 'level': 11, 'index': 0, 'type': 'external'},
+        {
+            'id': 102,
+            'level': 12,
+            'index': 0,
+            'type': 'transfer',
+            'target': {'address': ROLLUP},
+            'parameter': {'entrypoint': 'default', 'value': {}},
+        },
+    ]
+    node = FakeRollupNode({10: [], 11: _server_error()})
+    index = _index(FakeTzkt([page], head_level=12), node)
+    index._status = IndexStatus.syncing
+    # What `_prepare_new_index` would have seeded on the way into `syncing`; without it the
+    # drain would refuse every level as unreached and nothing would be fetched at all.
+    index._realtime_head_level = 12
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await index._process()
+
+    # The cursor is already past both externals...
+    assert await RollupInboxMessage.filter(id=102).exists()
+    # ...and the queue is what still knows the work is owed. Level 10 was drained but its
+    # messages were never flushed, so it stays pending too.
+    assert await _pending_levels() == [10, 11]
+
+    # Restart on the same database: the cursor cannot reach the externals, the queue can.
+    restarted = _index(FakeTzkt([[]], head_level=12), FakeRollupNode({10: [], 11: []}))
+    await restarted._prepare_new_index()
+    assert restarted._inbox_id_cursor == 103
+    assert restarted._outbox_level_queue == {10, 11}
+
+    await restarted._process()
+    assert restarted._rollup_node.requested == [10, 11]  # type: ignore[attr-defined]
+    assert await _pending_levels() == []
+
+
+async def test_full_outbox_continuation_level_survives_its_failed_fetch(db: Any) -> None:
+    """The continuation level of a full outbox is recoverable when its own fetch dies.
+
+    `outbox_level + 1` is queued *during* the drain, after the durability write of the page
+    that started it, so it is never in `dipdup_meta` under its own name. What keeps it
+    reachable is its parent: level L only leaves the stored set once `bulk_create` has
+    committed the rows it produced, and a drain that dies before that flush leaves L owed.
+    The restart re-fetches L, the full outbox re-derives L+1, and both land.
+
+    That is the invariant a per-level flush would break — committing L's rows mid-drain drops
+    L from the stored set while L+1 exists nowhere but in the dead process's memory.
+    """
+    head = 101
+    page = [
+        # The external message that puts level 100 in the queue...
+        {'id': 100, 'level': 100, 'index': 0, 'type': 'external'},
+        # ...followed by a transfer, so the committed cursor (`1 + max(id)`) is above it.
+        {
+            'id': 101,
+            'level': 100,
+            'index': 1,
+            'type': 'transfer',
+            'target': {'address': ROLLUP},
+            'parameter': {'entrypoint': 'default', 'value': {}},
+        },
+    ]
+    full_outbox = [_outbox_message(100, 0), _outbox_message(100, 1)]
+    assert len(full_outbox) == MAX_OUTBOX_MESSAGES_PER_LEVEL
+
+    node = FakeRollupNode({100: full_outbox, 101: _server_error()})
+    index = _index(FakeTzkt([page], head_level=head), node)
+    index._status = IndexStatus.syncing
+    index._realtime_head_level = head
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await index._process()
+
+    # The full outbox at 100 asked for 101, and the chain had reached it — so it was fetched
+    # in the same drain, and died there.
+    assert node.requested == [100, 101]
+    # Nothing was committed: the batch of level 100 went down with the process.
+    assert await _outbox_rows() == []
+    # ...which is exactly why level 100 must still be owed. It is the only reachable record
+    # of level 101 as well.
+    assert await _pending_levels() == [100]
+
+    # Restart on the same database, with a rollup node that now answers for both levels.
+    restarted_node = FakeRollupNode({100: full_outbox, 101: [_outbox_message(101, 0)]})
+    restarted = _index(FakeTzkt([[]], head_level=head), restarted_node)
+    await restarted._prepare_new_index()
+    assert restarted._inbox_id_cursor == 102, 'the cursor is past both inbox messages of the failed page'
+    assert restarted._outbox_level_queue == {100}, 'the stored queue is what the cursor cannot describe'
+
+    await restarted._process()
+
+    assert restarted_node.requested == [100, 101], 'the continuation level is re-derived from its parent and picked back up'
+    assert await _outbox_rows() == [(100, 0), (100, 1), (101, 0)], 'the messages of both levels land'
+    assert await _pending_levels() == [], 'nothing is owed once the rows are committed'
+
+
+async def test_drain_serves_the_lowest_level_and_stops_at_the_head(db: Any) -> None:
+    """The drain asks only for what the chain has reached — and takes the lowest level first.
+
+    Both levels are queued up front here, which is what a restored queue looks like: the
+    ordering is a real choice, not a side effect of one level queueing the next. An arbitrary
+    `pop()` would reach above the head and ask the rollup node for a block it cannot answer
+    for, which is how a wedged node starts answering 500 for everything.
+    """
+    # 207/208 rather than any round pair: these are levels for which an unordered `pop()`
+    # hands back the *higher* one first, so the wrong implementation is observably wrong
+    # here instead of getting the right answer by luck.
+    head = 207
+    node = FakeRollupNode({207: [_outbox_message(207, 0)], 208: [_outbox_message(208, 0)]})
+    index = _index(FakeTzkt(head_level=head), node)
+    index._status = IndexStatus.realtime
+    index._realtime_head_level = head
+    index._outbox_level_queue = {207, 208}
+
+    await index._drain_outbox_levels()
+
+    assert node.requested == [207], 'level 208 is above the realtime head and must not be asked for'
+    assert await _outbox_rows() == [(207, 0)], 'only the reached level produced rows'
+    assert await _pending_levels() == [208], 'the unreached level stays owed'
+
+    # Once the head reaches it, the same queue drains the rest.
+    index._realtime_head_level = 208
+    await index._drain_outbox_levels()
+
+    assert node.requested == [207, 208]
+    assert await _outbox_rows() == [(207, 0), (208, 0)]
+    assert await _pending_levels() == []


### PR DESCRIPTION
Three defects on the same path, each one able to lose rollup messages permanently and silently:
the index reports `realtime`, `dipdup_head` sits at the chain head, and the row is simply absent.

## 1. The outbox levels a failed drain forgets

`RollupMessageIndex` learns which outbox levels to fetch from the `external` messages of the inbox
page it is walking, and keeps them in an in-memory set. `_process` committed the page's
`RollupInboxMessage` rows first and drained that set afterwards, through an unguarded fetch. The
resume cursor is derived from those committed rows.

So a page whose `external` messages are followed by any `transfer` came back from a failed drain
with its cursor above those externals, and their outbox levels were never requested again.

On 2026-08-20 a rollup node stopped applying blocks while still answering RPC, so every fetch above
its processed level returned 500. **20 outbox messages present on the node were absent from the
database**, the same 20 on the instance that follows the same node. Their withdrawals could not
match until the rows were reinserted by hand. Note the shape: the level that *failed* was one of
them, but the rest had already been fetched into the batch that was never flushed. One transient
cost the whole unflushed batch.

**Fix:** persist the queue itself, in DipDup's own key-value table (`dipdup_meta`) — not part of the
package schema, so no schema-hash change and no reindex. Two orderings carry the guarantee: the
queue reaches the database *before* the inbox rows that move the cursor past the externals that
filled it, and a level leaves the stored set only *after* its rows are committed.

Because durability is a write-ordering property rather than an exception handler, `SIGKILL`, OOM,
eviction and a cancelled coroutine land on the safe side too, not only the error that happened to be
observed. The process is still allowed to die on a failed fetch — unchanged and deliberate.

The full-outbox continuation level (`outbox_level + 1`, enqueued when a level returns the protocol
maximum) has no inbox message behind it, so no cursor can describe it; it is covered by the same
mechanism, because its parent stays owed until the rows are committed.

`dipdup_meta` survives a reindex wipe, so a database with no inbox rows drops the stored queue
rather than inheriting the queue of a history that no longer exists.

### Why not one transaction per pass instead

The obvious alternative — commit the inbox rows and the outbox rows atomically, and let the queue
stay a local variable — does not pay here. On the realtime path the writes are *already* atomic:
`TezosHeadIndex._process_queue` opens `in_transaction` around the handler, and `fire_handler`
deliberately does not ("Handlers are not atomic, levels are"). The only path that would gain
atomicity is the `on_restart` backfill, where system hooks run with `atomic=False` — and that is
exactly where page-atomicity is unaffordable: one 10 000-message page spans ~1100 distinct L1
levels, i.e. ~1100 sequential rollup-node fetches that would all have to succeed before anything
commits, across ~5 500 such pages on mainnet. That trades a data-loss bug for a liveness failure in
the one operation that repairs data loss.

## 2. The ceiling was the wrong chain

The drain refused levels above the **L1 head**. But the request goes to the rollup node, which
applies L1 blocks on its own schedule and can fall arbitrarily far behind while still answering RPC
— the 2026-08-20 fault exactly. The ceiling therefore said "go ahead" for levels the node
demonstrably could not serve, and the drain died on the first one.

The ceiling is now the node's own `global/block/head/level`, and the boundary is exact: that level
answers 200, the next answers 500 `kind: temporary`. A level above it is deferred and stays owed,
the same as a level the chain has not produced. `_realtime_head_level` was the old ceiling and
nothing else read it, so it is gone, along with the head lookup that seeded it.

## 3. One inbox message skipped per restart

The inbox is fetched with `id.gt=<cursor>`, so the cursor means *the last id consumed* — which is
what the in-run advance stores. Both places that derived it from persisted state stored the *next id
wanted* instead, and the message on that boundary was requested by neither run.

Raw TzKT ids are contiguous and `type.in=transfer,external` breaks the run only at level boundaries,
so a restart mid-page lands on a real message in 88% of cursor positions. A fresh database lost the
first message of its window every time. The lost message is either a `transfer`, whose deposit can
no longer be matched, or an `external`, whose outbox level is never queued — defect 1 through a
different door.

Two one-line changes.

## The trade

A persistently broken rollup node now blocks the inbox backfill instead of moving past it. That is
the point: it used to move past it by leaving a hole nothing would ever report.

## Tests

`tests/stand/cases/outbox_fetch_failure/` — six arms against a fault-injecting proxy over a real
previewnet window. Exit contract `0 GREEN / 1 RED / 2 VOID`, where VOID means an arm never reached
the state it was supposed to prove (an empty database must not read as a recovery) and RED means the
code did the wrong thing.

| arm | node | outcome |
|---|---|---|
| WEDGED | reports a level below both outbox levels | pass finishes, no outbox rows, levels owed |
| WEDGE-RECOVERY | caught up, same database | both levels indexed |
| CONTROL | healthy, fresh database | both levels indexed |
| TREATMENT | 500 on one outbox level | process dies, inbox rows committed, no outbox rows |
| TREATMENT-AGAIN | fault still armed | dies again on the same database |
| RECOVERY | healthy, same database | both levels indexed |

Each defect was measured red on the unfixed code with the instrument that later proves it green.

Unit tests cover what the block-bounded case cannot reach: the continuation level failing its own
fetch, a queue straddling the ceiling, and both cursor seams.

`_process` was 72 lines carrying the ordering that makes all of this work in the position of two
statements; it is now 14 and the rule is stated once, in the class docstring.

## Not covered

The stand case and the unit tests run on sqlite; the `dipdup_meta` write is untested against
Postgres. A reorg rollback cannot revert the stored queue — `Meta` is a plain Tortoise model and
produces no `dipdup_model_update` rows — which costs re-fetches that the outbox `ignore_conflicts`
absorbs; a reorg also leaves the in-memory cursors above reverted rows, which predates this branch
and is not addressed here. Meta writes are not benchmarked over a full backfill, where a page can
leave thousands of levels pending. And that a *stopped* node reports its frozen applied level rather
than an advancing one follows from what the endpoint means, verified as an exact boundary on a
healthy node, but was never observed on a broken one.
