### PR TITLE
feat(mainnet): index L2 Michelson XTZ deposits

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -1,3 +1,68 @@
+custom:
+  # Etherlink mainnet runs a Michelson runtime alongside the EVM one, so EVM↔tz aliases exist and the
+  # RuntimeGateway `originOf` precompile is authoritative. `custom` merges first-level only, so this
+  # block replaces the base one (dipdup.yaml) — restate here any key added there later.
+  # With `true` every EVM deposit/withdrawal handler resolves its account through the precompile; if
+  # the precompile is absent the call raises RuntimeGatewayUnsupportedError, which takes L1 indexing
+  # down with it. Must be a literal YAML bool: handlers/alias.py requires `isinstance(value, bool)`,
+  # and env substitution can only ever yield a string.
+  has_michelson_runtime: true
+
+datasources:
+  # DipDup merges -c files with a shallow top-level dict.update, so this block REPLACES the base
+  # `datasources` wholesale — every base datasource is restated verbatim below. Losing one is silent
+  # at boot; dropping `etherlink_subsquid` alone would break the five EVM indexes that list it.
+  tzkt:
+    kind: tezos.tzkt
+    url: ${TZKT_URL}
+
+  metadata:
+    kind: tzip_metadata
+    # ${NETWORK} is the compose config selector (= mainnet) and also the name the dipdup metadata
+    # service indexes this L1 under, so the base value is correct here as-is.
+    network: ${NETWORK}
+    url: ${METADATA_URL}
+
+  tezos_node:
+    kind: http
+    url: ${TEZOS_NODE_URL}
+
+  etherlink_node:
+    kind: evm.node
+    url: ${ETHERLINK_NODE_URL}
+    # Mirrored from the base config, where the full rationale lives: `ws_url` carries the node's
+    # websocket path for realtime heads (and the duplicate-head patch that goes with it), `http` is
+    # the client-side ratelimit — without it `ratelimit_rate` defaults to 0, i.e. no throttling.
+    ws_url: ${ETHERLINK_NODE_WS:-~}
+    http:
+      batch_size: 100
+      ratelimit_rate: 900
+      ratelimit_period: 60
+      ratelimit_sleep: 10
+
+  etherlink_subsquid:
+    kind: evm.subsquid
+    url: ${ETHERLINK_SUBSQUID_URL:-~}
+    api_key: ${SUBSQUID_API_KEY:-}
+
+  rollup_node:
+    kind: http
+    url: ${ROLLUP_NODE_URL}
+    http:
+      retry_count: 2
+      retry_sleep: 1.0
+      retry_multiplier: 1.0
+      connection_timeout: 1
+      request_timeout: 4
+
+  # L2 Michelson side of the rollup — a TzKT over the rollup's Michelson runtime. Base host only,
+  # DipDup appends `/v1` itself. Unreachable at boot is a crash loop, not degradation:
+  # TezosTzktDatasource.__aenter__ probes v1/protocols/current and raises DatasourceError before the
+  # database schema is even opened.
+  tezos_x_michelson_tzkt:
+    kind: tezos.tzkt
+    url: ${TEZOSX_MICHELSON_TZKT_URL}
+
 contracts:
   tezos_smart_rollup:
     kind: tezos
@@ -8,6 +73,14 @@ contracts:
     kind: tezos
     address: ${FAST_WITHDRAWAL_NATIVE_ADDRESS}
     typename: fast_withdrawal
+
+  # TEZLINK_DEPOSITOR — synthetic source of L1->L2 Michelson XTZ deposits: the kernel
+  # const [0u8; 22] (all-zero serialized implicit contract) rendered in base58. A kernel
+  # constant, not a deployment address — identical on every network.
+  # See handlers/michelson_deposit.py for the kernel citations.
+  tezos_x_michelson_depositor:
+    kind: tezos
+    address: tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU
 
   etherlink_rollup_kernel:
     kind: evm
@@ -167,6 +240,31 @@ indexes:
         from_: etherlink_rollup_kernel
       - callback: etherlink.on_xtz_deposit
         from_: etherlink_deposit_sender
+
+
+  # L2 Michelson XTZ deposits (tz1 receiver): synthetic pseudo-transactions emitted by the kernel from
+  # TEZLINK_DEPOSITOR, matched to the L1 leg by reconstructed op-hash
+  # (BridgeMatcher.check_pending_michelson_deposits, derivation in handlers/michelson_deposit.py).
+  # L2_MICHELSON_FIRST_LEVEL is an Etherlink L2 block number — the Michelson runtime shares the EVM
+  # block counter — and must be the first level that runtime exists at: earlier synthetic ops use an
+  # unverified derivation and would sit unmatched forever, and an unset value backfills from genesis.
+  # Above the Michelson TzKT's head at boot it freezes the WHOLE indexer with no error and no log
+  # line — the index never leaves status `new`, so no datasource ever opens a websocket.
+  # Adding an index leaves every existing index's config hash byte-identical, so this needs no reindex.
+  tezos_x_michelson_deposits:
+    kind: tezos.operations
+    first_level: ${L2_MICHELSON_FIRST_LEVEL}
+    datasources:
+      - tezos_x_michelson_tzkt
+    types:
+      - transaction
+    contracts:
+      - tezos_x_michelson_depositor
+    handlers:
+      - callback: tezos_x.on_michelson_deposit_ophash
+        pattern:
+          - type: transaction
+            source: tezos_x_michelson_depositor
 
 
   etherlink_withdrawal_events:


### PR DESCRIPTION
Enables the tz1-receiver (L2 Michelson) XTZ deposit path on mainnet. Config only — every handler,
model and matcher step already ships in the image and runs on `tezosx-shadownet`; `configs/mainnet.yaml`
simply never declared the pieces.

Four additions to `configs/mainnet.yaml`:

| | |
| --- | --- |
| `custom.has_michelson_runtime: true` | Makes `resolve_l2_account` consult the RuntimeGateway precompile instead of recording every EVM address as native. |
| datasource `tezos_x_michelson_tzkt` | A TzKT over the rollup's Michelson runtime (`TEZOSX_MICHELSON_TZKT_URL`). |
| contract `tezos_x_michelson_depositor` | The kernel's synthetic deposit source — a kernel constant, identical on every network. |
| index `tezos_x_michelson_deposits` | Indexes those synthetic transactions from `L2_MICHELSON_FIRST_LEVEL`. |

Worth knowing before touching this config:

- `has_michelson_runtime` must be a literal YAML bool — `handlers/alias.py` requires
  `isinstance(value, bool)`, so it cannot come from an env var.
- With it `true`, every EVM deposit/withdrawal handler resolves through the precompile. If the
  precompile is absent the call raises `RuntimeGatewayUnsupportedError`, and because one of those
  handlers is `tezos.on_rollup_call`, that takes L1 indexing down too.
- `L2_MICHELSON_FIRST_LEVEL` is an **Etherlink L2 block number** — the Michelson runtime shares the EVM
  block counter. Unset means a backfill from genesis. A value above the Michelson TzKT's head at boot
  freezes the *whole* indexer with no error and no log line: the index never leaves status `new`, so no
  datasource ever opens a websocket.
- The overlay had no `datasources` block before. DipDup's `-c` merge is a shallow top-level
  `dict.update`, so adding one replaces the base block wholesale — all six base datasources are restated
  verbatim.
- Adding an index leaves every existing index's config hash byte-identical, so no reindex.

Verified against master with a merged `config export`: seven datasources, ten indexes, and the only
non-addition in the diff is `has_michelson_runtime: false` → `true`.

The deployment procedure lives in the private deployments repo, at
`stacks/etherlink-bridge-indexer/ENABLE-L2-MICHELSON.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
